### PR TITLE
Add iOS Docs

### DIFF
--- a/source/includes/_install_ios.md
+++ b/source/includes/_install_ios.md
@@ -1,0 +1,164 @@
+# Installing iOS SDK
+
+## Using Cocoapods
+
+```
+// Install Cocoapods 
+$ gem install cocoapods
+
+//Inside your Podfile
+target 'YourProject' do
+  pod 'WootricSDK'
+end
+
+// Install pods
+$ pod install
+```
+
+**1. Install CocoaPods**
+
+If you don't have Cocoapods already, you can install it by typing 
+`$ gem install cocoapods` in your terminal
+
+**2. Podfile**
+
+Create a `Podfile` and add `pod 'WootricSDK'`. This will download and install the latest version of the SDK. If you want to you can specify which version of the SDK by doing something like this `pod 'WootricSDK', '0.5.6'`. For more information about creating this file, please refer to Cocoapod's [Podfile Guide](https://guides.cocoapods.org/using/the-podfile.html).
+
+
+**3. Install WootricSDK**
+
+On your terminal, and inside your project's directory, run `$ pod install`. Cocoapods will download all dependencies specified in your `Podfile`. From now on, you should use the `.xcworkspace` file instead of the `.xcodeproject` file.
+
+##Carthage
+
+**1. Install Carthage**
+
+If you haven't already, install the latest version of Carthage.
+
+**2. Cartfile**
+
+Add `github "Wootric/WootricSDK-iOS"` to your Cartfile, and follow the Carthage installation instructions.
+
+**3. Update SDK**
+
+ In the future, to update to the latest version of the SDK, run `carthage update --platform ios`.
+
+##Dynamic Framework
+
+Note: This is only compatible with iOS 8 and above.
+
+**1. Download SDK**
+
+Head to our [GitHub releases page](https://github.com/Wootric/WootricSDK-iOS/releases) and download and unzip WootricSDK.framework
+
+**2. Add the framework to your project**
+
+Drag WootricSDK.framework to the "Embedded Binaries" section of your Xcode project's "General" settings. Make sure to select "Copy items if needed"
+
+![Xcode](https://cloud.githubusercontent.com/assets/1431421/16505349/238edd62-3ee2-11e6-8f91-9d3c978a10cf.png)
+
+# Presenting the survey
+
+## Step 1. Initialize Wootric
+``` objective_c
+#import <WootricSDK/WootricSDK.h>
+// In you view controller
+
+[Wootric configureWithClientID:<YOUR_CLIENT_ID> clientSecret:<YOUR_CLIENT_SECRET> accountToken:<YOUR_ACCOUNT_TOKEN>];
+// TODO: The current logged in user's email address.
+[Wootric setEndUserEmail:@"nps@example.com"];
+// TODO: The current logged in user's sign-up date as a Unix timestamp.
+[Wootric setEndUserCreatedAt:@1234567890];
+
+[Wootric showSurveyInViewController:<YOUR_VIEW_CONTROLLER>];
+
+```
+
+``` swift
+// In you view controller
+
+Wootric.configureWithClientID(<YOUR_CLIENT_ID>, clientSecret: <YOUR_CLIENT_SECRET>, accountToken: <YOUR_ACCOUNT_TOKEN>)
+
+// TODO: The current logged in user's email address.
+Wootric.setEndUserEmail("nps@example.com")
+// TODO: The current logged in user's sign-up date as a Unix timestamp.
+Wootric.setEndUserCreatedAt(1234567890)
+
+Wootric.showSurveyInViewController(<YOUR_VIEW_CONTROLLER>)
+
+```
+Once you are signed up on the Wootric homepage, you will be taken directly to an installation page. If you’re a returning visitor, sign in at [wootric.com](https://www.wootric.com/) and click on the “Settings" button near the top right of the page. Navigate to the [Wootric Installation Guide](https://app.wootric.com/install) and you will see a unique **account_token** for you to use.
+
+The **client_id** and **client_secret** can be found on your account's settings [API section](https://app.wootric.com/account_settings/edit#!/api).
+
+<aside class="warning">
+If you are using Swift, don't forget to import WootricSDK in your `Bridging-Header.h`
+</aside>
+
+
+##Step 2. Customize the Survey
+
+> Comment out the line `[Wootric forceSurvey:YES]` or `Wootric.forceSurvey(true)` when you are ready for production. Alternatively, leave the line in the code for testing purposes or to survey the customer upon every visit to a view.
+
+```objective_c
+#import <WootricSDK/WootricSDK.h>
+
+[Wootric configureWithClientID:@"your_client_id" clientSecret:@"your_client_secret" accountToken:@"NPS­-xxxxxxxx"];
+[Wootric setEndUserEmail:@"nps@example.com"];
+[Wootric setEndUserCreatedAt:@1234567890];
+// Fire immediately for testing
+[Wootric forceSurvey:YES];
+
+// Customization
+[Wootric setCustomProductName:@"Wootric"];
+[Wootric setCustomFinalThankYou:@"Merci!"];
+[Wootric setCustomLanguage:@"fr"];
+
+[Wootric showSurveyInViewController:self];
+```
+
+```swift
+// In you view controller
+
+Wootric.configureWithClientID("your_client_id", clientSecret: "your_client_secret", accountToken: "NPS­-xxxxxxxx")
+Wootric.setEndUserEmail("nps@example.com")
+Wootric.setEndUserCreatedAt(1234567890)
+
+// Fire immediately for testing
+Wootric.forceSurvey(true)
+
+// Customization
+Wootric.setCustomProductName("Wootric")
+Wootric.setCustomFinalThankYou("Merci!")
+Wootric.setCustomLanguage("fr")
+
+Wootric.showSurveyInViewController(self)
+```
+
+This is an important step! [Customize](https://app.wootric.com/user_settings/edit#!/survey-nps) your survey with the name of your product or company. As needed, make changes to our trusted [survey](https://app.wootric.com/user_settings/edit#!/survey-nps) and [sampling](https://app.wootric.com/user_settings/edit#!/sampling) defaults. This values can modified from your app.
+
+## Step 3. View your Responses Live!
+That's it! Once the WootricSDK is installed, eligible users will immediately start being surveyed.
+Depending on the traffic of your app, you could start to see responses within a few minutes.
+Responses will come in to your Wootric dash in real time.
+
+
+### **No data yet?**
+We provide a link within your empty dashboard to a sample dash with dummy
+data.
+### **I’d like to do some testing first. How do I ensure that the survey shows up on demand?**
+
+You can easily install Wootric in your development environment for testing. The SDK is
+already set up to show the survey immediately for testing purposes only.
+
+### Additional notes on WootricSDK placement:
+
+#### For apps with registered users:
+If your app has registered users, we recommend that you
+show the survey only on views that your logged in users will access to allow unique user
+identification.
+
+#### For ecommerce apps:
+If your app has a checkout flow, we recommend that you show the survey
+on views that won’t interrupt checkout. The most commonly used location is the transaction
+completion page.

--- a/source/includes/_ios_custom_fields.md
+++ b/source/includes/_ios_custom_fields.md
@@ -1,0 +1,98 @@
+# SDK Reference
+
+## setEndUserEmail
+```objective_c
+[Wootric setEndUserEmail:<END_USER_EMAIL>];
+```
+```swift
+Wootric.setEndUserEmail(<END_USER_EMAIL>)
+```
+While end user email is not required it is HIGHLY recommended to set it if possible.
+
+## forceSurvey
+```objective_c
+[Wootric forceSurvey:<BOOL>];
+```
+```swift
+Wootric.forceSurvey(<BOOL>)
+```
+If forceSurvey is set to YES, the survey is displayed skipping eligibility check AND even if user was already surveyed. This is for test purposes only as it will display the survey every time and for every user.
+
+##surveyImmediately
+```objective_c
+[Wootric surveyImmediately:<BOOL>];
+```
+```swift
+Wootric.surveyImmediately(<BOOL>)
+```
+If surveyImmediately is set to YES and user wasn't surveyed yet - eligibility check will return "true" and survey will be displayed. This shouldn't be used on production.
+
+##setEndUserCreatedAt
+```objective_c
+[Wootric setEndUserCreatedAt:<UNIX Timestamp>];
+```
+```swift
+Wootric.setEndUserCreatedAt(<UNIX Timestamp>)
+```
+When creating a new end user for survey, it will set his/hers external creation date (so for example, date, when end user was created in your iOS application).
+This value is also used in eligibility check, to determine if end user should be surveyed.
+
+##setFirstSurveyAfter
+```objective_c
+[Wootric setFirstSurveyAfter:<NUMBER_OF_DAYS>];
+```
+```swift
+Wootric.setFirstSurveyAfter(<NUMBER_OF_DAYS>)
+```
+If not set, defaults to value from admin panel. Used to check if end user was created/last seen earlier than <NUMBER_OF_DAYS> ago and therefore if survey is required.
+
+##setEndUserProperties
+```objective_c
+[Wootric setEndUserProperties:<NSDICTIONARY>];
+```
+```swift
+Wootric.setEndUserProperties(<NSDICTIONARY>)
+```
+Adds properties object to end user.
+
+##setProductNameForEndUser
+```objective_c
+[Wootric setProductNameForEndUser:<PRODUCT_NAME>];
+```
+```swift
+Wootric.setProductNameForEndUser(<PRODUCT_NAME>)
+```
+Directly adds a product name to end user's properties.
+
+##setSurveyedDefault
+```objective_c
+[Wootric setSurveyedDefault:<BOOL>];
+```
+```swift
+Wootric.setSurveyedDefault(<BOOL>)
+```
+Right after a vote or dismiss we are setting a NSUserDefault that lasts for 90 days and indicates that end user was already surveyed on this device. We are doing this to lower the requests amount to our eligibility server.
+If your survey throttle is different than 90 days and/or you don't want to set the surveyed "cookie" you can set this option to `NO`.
+
+##passScoreAndTextToURL
+```objective_c
+[Wootric passScoreAndTextToURL:<BOOL>];
+```
+```swift
+Wootric.passScoreAndTextToURL(<BOOL>)
+```
+If you enable this setting, score and feedback text will be added as wootric_score and wootric_text params to the "thank you" URL you have provided. (Check "Custom Thank You" section)
+
+##skipFeedbackScreenForPromoter
+```objective_c
+[Wootric skipFeedbackScreenForPromoter:<BOOL>];
+```
+```swift
+Wootric.skipFeedbackScreenForPromoter(<BOOL>)
+```
+With this option enabled, promoters (score 9-10) will be taken directly to third (social share) screen, skipping the second (feedback) one.
+
+
+
+
+

--- a/source/includes/_ios_custom_language.md
+++ b/source/includes/_ios_custom_language.md
@@ -1,0 +1,18 @@
+# Custom language, audience text and product name configuration:
+---
+
+```objective_c
+[Wootric setCustomLanguage:<LANGUAGE_CODE>];
+[Wootric setCustomAudience:<CUSTOM_AUDIENCE>];
+[Wootric setCustomProductName:<CUSTOM_PRODUCT_NAME>];
+```
+```swift
+Wootric.setCustomLanguage(<LANGUAGE_CODE>)
+Wootric.setCustomAudience(<CUSTOM_AUDIENCE>)
+Wootric.setCustomProductName(<CUSTOM_PRODUCT_NAME>)
+```
+Please refer to our [docs](http://docs.wootric.com/install/#custom-language-setting) for available languages.
+
+Custom audience and/or product name modifies the default NPS question e.g. default question in English looks like this:
+"How likely are you to recommend this product or service to a friend or co-worker?"
+if custom product name is set it will substitute "this product or service" text, while custom audience will substitute "friend or co-worker". It also takes precedence over values set in admin panel.

--- a/source/includes/_ios_custom_thank_you.md
+++ b/source/includes/_ios_custom_thank_you.md
@@ -1,0 +1,78 @@
+# Custom Thank You
+---
+
+```objective_c
+// Social share setup
+[Wootric setFacebookPage:<FACEBOOK_PAGE_URL>];
+[Wootric setTwitterHandler:<TWITTER_HANDLER>];
+
+// Custom thank you messages setup
+[Wootric setThankYouMessage:<THANK_YOU_MESSAGE>];
+[Wootric setDetractorThankYouMessage:<THANK_YOU_MESSAGE>];
+[Wootric setPassiveThankYouMessage:<THANK_YOU_MESSAGE>];
+[Wootric setPromoterThankYouMessage:<THANK_YOU_MESSAGE>];
+
+// Custom thank you button setup
+[Wootric setThankYouLinkWithText:<THANK_YOU_TEXT> URL:<THANK_YOU_URL>];
+[Wootric setDetractorThankYouLinkWithText:<THANK_YOU_TEXT> URL:<THANK_YOU_URL>];
+[Wootric setPassiveThankYouLinkWithText:<THANK_YOU_TEXT> URL:<THANK_YOU_URL>];
+[Wootric setPromoterThankYouLinkWithText:<THANK_YOU_TEXT> URL:<THANK_YOU_URL>];
+```
+```swift
+// Social share setup
+Wootric.setFacebookPage(<FACEBOOK_PAGE_URL>)
+Wootric.setTwitterHandler(<TWITTER_HANDLER>)
+
+// Custom thank you messages setup
+Wootric.setThankYouMessage(<THANK_YOU_MESSAGE>)
+Wootric.setDetractorThankYouMessage(<THANK_YOU_MESSAGE>)
+Wootric.setPassiveThankYouMessage(<THANK_YOU_MESSAGE>)
+Wootric.setPromoterThankYouMessage(<THANK_YOU_MESSAGE>)
+
+// Custom thank you button setup
+Wootric.setThankYouLinkWithText(<THANK_YOU_TEXT>, URL:<THANK_YOU_URL>)
+Wootric.setDetractorThankYouLinkWithText(<THANK_YOU_TEXT>, URL:<THANK_YOU_URL>)
+Wootric.setPassiveThankYouLinkWithText(<THANK_YOU_TEXT>, URL:<THANK_YOU_URL>)
+Wootric.setPromoterThankYouLinkWithText(<THANK_YOU_TEXT>, URL:<THANK_YOU_URL>)
+```
+
+If configured, social share will display third screen for promoters (score 9-10, also twitter displays only if there is a feedback text provided), while custom thank you message and/or button will display for each type of end user that is configured (where ```setThankYouMessage:``` and ```setThankYouLinkWithText:URL:``` being default for any score).
+
+For detailed information please refer to [js docs](http://docs.wootric.com/install/#social-media-share-settings).
+
+# Color Customization (iPhone only)
+---
+
+```objective_c
+// Change slider color
+[Wootric setSliderColor:<UI_COLOR>];
+
+// Change Send button color
+[Wootric setSendButtonBackgroundColor:<UI_COLOR>];
+
+// Change Thank You button color
+[Wootric setThankYouButtonBackgroundColor:<UI_COLOR>];
+
+// Change Social buttons color
+[Wootric setSocialSharingColor:<UI_COLOR>];
+```
+```swift
+// Change slider color
+Wootric.setSliderColor(<UI_COLOR>)
+
+// Change Send button color
+Wootric.setSendButtonBackgroundColor(<UI_COLOR>)
+
+// Change Thank You button color
+Wootric.setThankYouButtonBackgroundColor(<UI_COLOR>)
+
+// Change Social buttons color
+Wootric.setSocialSharingColor(<UI_COLOR>)
+```
+
+Appereance of the survey can be modified to match your apps colors. The survey slider, Send button, Thank You button and all social sharing buttons can be modified.
+
+# Additional information
+
+First survey after & end user created at setting:
+While it is not required, setting ```setEndUserCreatedAt``` is highly recommended for proper checking if end user needs survey and skipping uneccessary eligibility checks.

--- a/source/includes/_ios_view_config.md
+++ b/source/includes/_ios_view_config.md
@@ -1,0 +1,50 @@
+# Per view configuration
+
+While Wootric is using values you have set in admin panel, it is possible to override these values directly in code.
+
+##setCustomNPSQuestion
+```objective_c
+[Wootric setCustomNPSQuestion:<NPS_QUESTION>];
+```
+```swift
+Wootric.setCustomNPSQuestion(<NPS_QUESTION>)
+```
+Changes NPS Question from admin panel to provided value (English default is "How likely are you to recommend this product or service to a friend or co-worker?").
+
+##setCustomFinalThankYou
+```objective_c
+[Wootric setCustomFinalThankYou:<FINAL_THANK_YOU>];
+```
+```swift
+Wootric.setCustomFinalThankYou(<FINAL_THANK_YOU>)
+```
+Changes final thank you from admin panel to provided value (English default is "Thank you for your response, and your feedback!).
+
+##setCustomValueForResurveyThrottle:visitorPercentage:registeredPercentage:dailyResponseCap:
+```objective_c
+// You can pass nil value for any of the parameters - it will use defaults for eligibility check if you do so.
+[Wootric setCustomValueForResurveyThrottle:<NUMBER_OF_DAYS> visitorPercentage:<0-100> registeredPercentage:<0-100> dailyResponseCap:<0-...>];
+```
+```swift
+// You can pass nil value for any of the parameters - it will use defaults for eligibility check if you do so.
+Wootric.setCustomValueForResurveyThrottle(<NUMBER_OF_DAYS>, visitorPercentage:<0-100>, registeredPercentage:<0-100>, dailyResponseCap:<0-...>)
+```
+This method will alter the values of resurvey throttle, tested visitor, registered users percentage and daily response cap used for eligibility check.
+
+##setCustomFollowupQuestionForPromoter:passive:detractor:
+```objective_c
+[Wootric setCustomFollowupQuestionForPromoter:<CUSTOM_QUESTION> passive:<CUSTOM_QUESTION> detractor:<CUSTOM_QUESTION>];
+```
+```swift
+Wootric.setCustomFollowupQuestionForPromoter(<CUSTOM_QUESTION>, passive:<CUSTOM_QUESTION>, detractor:<CUSTOM_QUESTION>)
+```
+This method allows you to set custom question for each type of end user (detractor, passive or promoter). Passing ```nil``` for any of the parameters will result in using defaults set in Wootric's admin panel for that type of end user.
+
+##setCustomFollowupPlaceholderForPromoter:passive:detractor:
+```objective_c
+[Wootric setCustomFollowupPlaceholderForPromoter:<CUSTOM_PLACEHOLDER> passive:<CUSTOM_PLACEHOLDER> detractor:<CUSTOM_PLACEHOLDER>];
+```
+```swift
+Wootric.setCustomFollowupPlaceholderForPromoter(<CUSTOM_PLACEHOLDER>, passive:<CUSTOM_PLACEHOLDER>, detractor:<CUSTOM_PLACEHOLDER>)
+```
+Same as with custom question, it allows you to set custom placeholder text in feedback text view for each type of end user. Be advised that this setting takes precedence over values set in Wootric's from admin panel.

--- a/source/index.md
+++ b/source/index.md
@@ -7,7 +7,7 @@ Here is a list of the docs to integrate and use Wootric. It should not take more
 <br><br>
 * <a href="/segment" style="text-decoration:none;color:#000">Install Wootric using Segment.com</a>
 <br><br>
-* <a href="https://github.com/Wootric/WootricSDK-iOS/blob/master/README.md" style="text-decoration:none;color:#000">Install Wootric using iOS SDK</a>
+* <a href="/ios" style="text-decoration:none;color:#000">Install Wootric using iOS SDK</a>
 <br><br>
 * <a href="https://github.com/Wootric/WootricSDK-Android/blob/master/README.md" style="text-decoration:none;color:#000">Install Wootric using Android SDK</a>
 <br><br>

--- a/source/ios.html.erb
+++ b/source/ios.html.erb
@@ -1,0 +1,18 @@
+---
+title: iOS Documentation
+
+language_tabs:
+  - objective_c: Objective-C
+  - swift: Swift
+
+toc_footers:
+  - <a href='https://www.wootric.com/'>Sign Up</a>
+  - <a href='http://github.com/tripit/slate'>Documentation Powered by Slate</a>
+
+search: true
+---
+<%= partial "includes/install_ios" %>
+<%= partial "includes/ios_custom_fields" %>
+<%= partial "includes/ios_view_config" %>
+<%= partial "includes/ios_custom_language" %>
+<%= partial "includes/ios_custom_thank_you" %>

--- a/source/stylesheets/variables.scss
+++ b/source/stylesheets/variables.scss
@@ -46,7 +46,7 @@ $main-text: #333; // main content text color
 $nav-text: #fff;
 $nav-active-text: #fff;
 $lang-select-text: #fff; // color of unselected language tab text
-$lang-select-active-text: #fff; // color of selected language tab text
+$lang-select-active-text: #000; // color of selected language tab text
 $lang-select-pressed-text: #fff; // color of language tab text when mouse is pressed
 
 


### PR DESCRIPTION
iOS documentation added to slate. To test these
changes and see how they would look with Slate,
I suggest following instructions of the README
on https://github.com/Wootric/slate/tree/wootric-master
but insted of `git checkout wootric-master`, try with
`git checkout ds-ios-docs`