### PR TITLE
Add Android docs & update iOS docs

### DIFF
--- a/source/android.html.erb
+++ b/source/android.html.erb
@@ -1,0 +1,16 @@
+---
+title: Android Documentation
+
+toc_footers:
+  - <a href='https://www.wootric.com/'>Sign Up</a>
+  - <a href='http://github.com/tripit/slate'>Documentation Powered by Slate</a>
+
+search: true
+---
+<%= partial "includes/install_android" %>
+<%= partial "includes/android_custom_fields" %>
+<%= partial "includes/android_custom_language" %>
+<%= partial "includes/android_custom_thank_you" %>
+<%= partial "includes/android_samples" %>
+<%= partial "includes/android_troubleshooting" %>
+<%= partial "includes/android_integrations" %>

--- a/source/includes/_android_custom_fields.md
+++ b/source/includes/_android_custom_fields.md
@@ -1,0 +1,43 @@
+# SDK Reference
+
+##setEndUserEmail
+```java
+wootric.setEndUserEmail(<END_USER_EMAIL>);
+```
+While end user email is not required it is HIGHLY recommended to set it if possible.
+
+
+##setSurveyImmediately
+```java
+wootric.setSurveyImmediately(<BOOL>);
+```
+If setSurveyImmediately is set to `true` and user wasn't surveyed yet - eligibility check will return `true` and survey will be displayed.
+
+<aside class="warning">
+This should not be used in production.
+</aside>
+
+##setEndUserCreatedAt
+```java
+wootric.setEndUserCreatedAt(<UNIX Timestamp>);
+```
+When creating a new end user for survey, it will set the external creation date (so for example, date, when end user was created in your Android application).
+This value is also used in eligibility check, to determine if end user should be surveyed.
+
+##setFirstSurveyDelay
+```java
+wootric.setFirstSurveyDelay(<NUMBER_OF_DAYS>);
+```
+If not set, defaults to value from admin panel. Used to check if end user was created/last seen earlier than <NUMBER_OF_DAYS> ago and therefore if survey is required.
+
+##setProperties
+```java
+wootric.setProperties(properties);
+```
+End user properties can be provided as a `HashMap<String, String>` object.
+
+##shouldSkipFollowupScreenForPromoters
+```java
+wootric.shouldSkipFollowupScreenForPromoters(<BOOL>);
+```
+With this option enabled, promoters (score 9-10) will be taken directly to third (social share) screen, skipping the second (feedback) one.

--- a/source/includes/_android_custom_language.md
+++ b/source/includes/_android_custom_language.md
@@ -1,0 +1,14 @@
+# Custom language, audience text and product name configuration:
+---
+
+```java
+wootric.setLanguageCode(<LANGUAGE_CODE>);
+wootric.setRecommendTarget(<CUSTOM_AUDIENCE>);
+wootric.setProductName(<CUSTOM_PRODUCT_NAME>);
+```
+Please refer to our [docs](http://docs.wootric.com/install/#custom-language-setting) for available languages.
+
+
+`setProductName` sets the product name for the end user. This will change the default question.
+e.g. How likely are you to recommend productName to a friend or co-worker?
+`setRecommendTarget` will substitute "friend or co-worker". It also takes precedence over values set in admin panel.

--- a/source/includes/_android_custom_thank_you.md
+++ b/source/includes/_android_custom_thank_you.md
@@ -1,0 +1,58 @@
+# Custom messages
+```java
+WootricCustomMessage customMessage = new WootricCustomMessage();
+customMessage.setFollowupQuestion("custom followup");
+customMessage.setDetractorFollowupQuestion("custom detractor");
+customMessage.setPassiveFollowupQuestion("custom passive");
+customMessage.setPromoterFollowupQuestion("custom promoter");
+customMessage.setPlaceholderText("custom placeholder");
+customMessage.setDetractorPlaceholderText("custom detractor placeholder");
+customMessage.setPassivePlaceholderText("custom passive placeholder");
+customMessage.setPromoterPlaceholderText("custom promoter placeholder");
+
+wootric.setCustomMessage(customMessage);
+```
+
+Wootric provides designated class for providing custom messages -`WootricCustomMessages`
+
+# Custom thank you
+
+```java
+WootricCustomThankYou customThankYou = new WootricCustomThankYou();
+customThankYou.setText("Thank you!!");
+customThankYou.setDetractorText("Detractor thank you");
+customThankYou.setPassiveText("Passive thank you");
+customThankYou.setPromoterText("Promoter thank you");
+customThankYou.setLinkText("Thank you link text");
+customThankYou.setDetractorLinkText("Detractor link text");
+customThankYou.setPassiveLinkText("Passive link text");
+customThankYou.setPromoterLinkText("Promoter link text");
+customThankYou.setLinkUri(Uri.parse("http://wootric.com/thank_you"));
+customThankYou.setDetractorLinkUri(Uri.parse("http://wootric.com/detractor_thank_you"));
+customThankYou.setPassiveLinkUri(Uri.parse("http://wootric.com/passive_thank_you"));
+customThankYou.setPromoterLinkUri(Uri.parse("http://wootric.com/promoter_thank_you"));
+customThankYou.setScoreInUrl(true);
+customThankYou.setCommentInUrl(true);
+wootric.setCustomThankYou(customThankYou);
+```
+
+Wootric provides designated class for providing custom thank you -`WootricCustomThankYou`
+
+
+# Color customization (smartphones only)
+```java
+// Changes background color and text buttons color for the survey
+wootric.setSurveyColor(R.color.survey_color);
+
+// Changes score selector color and comment highlight color
+wootric.setScoreColor(R.color.score_color);
+
+// Changes Thank You button color on the final view
+wootric.setThankYouButtonBackgroundColor(R.color.thank_you_color);
+
+// Changes Facebook and Twitter buttons colors
+wootric.setSocialSharingColor(R.color.social_color);
+```
+Colors can be customized for the smartphone's version.
+
+

--- a/source/includes/_android_integrations.md
+++ b/source/includes/_android_integrations.md
@@ -1,0 +1,91 @@
+# Segment Integration
+
+Wootric provides an integration for [Segment](https://segment.com/). The library can be found on [our Github](https://github.com/Wootric/segment-android-integration-wootric). 
+
+This library is distributed as Android library project so it can be included by referencing it as a library project.
+
+##Install with Maven
+```xml
+<dependency>
+    <groupId>com.wootric</groupId>
+    <artifactId>analytics-integration-wootric</artifactId>
+    <version>0.1.4</version>
+</dependency>
+```
+If you use Maven, you can include this library as a dependency.
+
+##Install with Gradle
+```groovy
+compile 'com.wootric:analytics-integration-wootric:0.1.4'
+
+dependencies {
+  repositories {
+    mavenCentral()
+    maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' }
+  }
+
+  compile 'com.segment.analytics.android:analytics:4.1.4-SNAPSHOT'
+}
+```
+
+It is assumed that Segment's android analytics is available. The latest version can be added as dependency this way.
+
+##Intialize Analytics
+```java
+import com.segment.analytics.Analytics;
+import com.wootric.analytics.android.integrations.wootric.WootricIntegration;
+
+public class MainApplication extends Application {
+
+    Analytics analytics;
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+
+        analytics = new Analytics.Builder(this, "write_key")
+                .use(WootricIntegration.FACTORY)
+                .build();
+    }
+
+    public Analytics getAnalytics() {
+        return analytics;
+    }
+}
+```
+
+Analytics object should be initialized in the Application class, specifying that the WootricIntegration should be user.
+
+##Wootric object
+```java
+
+import com.segment.analytics.Analytics;
+import com.wootric.analytics.android.integrations.wootric.WootricIntegration;
+import com.wootric.androidsdk.Wootric;
+
+public class MainActivity extends Activity {
+    @Override
+    protected void onResume() {
+        super.onResume();
+
+        Analytics analytics = ((MainApplication) getApplication()).getAnalytics();
+        analytics.onIntegrationReady(WootricIntegration.FACTORY.key(), new Analytics.Callback<Wootric>() {
+            @Override
+            public void onReady(Wootric wootric) {
+                // Set all aptional configuration here like:
+                // wootric.setSurveyImmediately(true);
+                // wootric.setLanguageCode("PL");
+                wootric.survey();
+            }
+        });
+    }
+}
+```
+
+In your Activity of choosing the Wootric object can be used to set all optional configurations and call `survey()` method.
+
+# mParticle Integration
+
+Wootric provides an integration for [mParticle](http://mparticle.com/). 
+
+Instructions on how to setup the mParticle Android SDK can be found on [mParticle's Github](https://github.com/mParticle/mparticle-android-sdk).

--- a/source/includes/_android_samples.md
+++ b/source/includes/_android_samples.md
@@ -1,0 +1,66 @@
+# Samples
+
+## Rate application on the Play Store
+```java
+
+import com.wootric.androidsdk.Wootric;
+import com.wootric.androidsdk.objects.WootricCustomThankYou;
+
+...
+
+Wootric wootric = Wootric.init(this, CLIENT_ID, CLIENT_SECRET, ACCOUNT_TOKEN);
+
+wootric.setEndUserEmail("nps@example.com");
+
+// Uncomment for testing
+// NOTE: do not use in production
+// wootric.setSurveyImmediately(true);
+
+// Will skip the Feedback view for Promoters
+wootric.shouldSkipFollowupScreenForPromoters(true);
+
+WootricCustomThankYou customThankYou = new WootricCustomThankYou();
+Uri uri = Uri.parse("market://details?id=com.yourcompany.appid");
+customThankYou.setPromoterLinkText("Rate our app!");
+customThankYou.setPromoterLinkUri(uri);
+
+wootric.setCustomThankYou(customThankYou);
+wootric.survey();
+```
+
+You can set the last button to go to the Play Store so users can rate your app.
+
+<p align="center" >
+  <img src="https://cloud.githubusercontent.com/assets/1431421/16964379/bc8e7c06-4dc0-11e6-900a-bf6a3d4501b6.png" alt="Wootric" title="Wootric" style="height:400px;">
+</p>
+
+## Set End User Properties
+```java
+import com.wootric.androidsdk.Wootric;
+import com.wootric.androidsdk.objects.WootricCustomThankYou;
+import java.util.HashMap;
+
+...
+
+Wootric wootric = Wootric.init(this, CLIENT_ID, CLIENT_SECRET, ACCOUNT_TOKEN);
+
+wootric.setEndUserEmail("nps@example.com");
+
+// Uncomment for testing
+// NOTE: do not use in production
+// wootric.setSurveyImmediately(true);
+
+// Set end user's properties
+HashMap<String, String> properties = new HashMap<String, String>();
+properties.put("company", "Wootric");
+properties.put("type", "awesome");
+properties.put("os", "Android");
+wootric.setProperties(properties);
+
+wootric.survey();
+```
+Setting end user properties will help you segment and filter results.
+
+<p align="center" >
+  <img src="https://cloud.githubusercontent.com/assets/1431421/17043713/0b202224-4f7f-11e6-86cf-3193cfda998f.png" alt="Properties" title="Wootric">
+</p>

--- a/source/includes/_android_troubleshooting.md
+++ b/source/includes/_android_troubleshooting.md
@@ -1,0 +1,17 @@
+# Troubleshooting
+
+**Survey not showing up?**
+
+Check that client ID, client secret and account token are correct. Account token should have a "NPS-xxxxxxxx" format
+
+**Does the SDK work with Amazon devices?**
+
+Yes, the SDK has been tested with Amazon devices.
+
+**I'm using `setSurveyImmediately` but getting `User not eligible`**
+
+Check that Wootric Mobile Switch is enabled on your [Acount Settings](https://app.wootric.com/account_settings/edit?#!/account)
+
+<p align="center" >
+  <img src="https://cloud.githubusercontent.com/assets/1431421/17071952/562c86da-502a-11e6-8362-48aac99ced6a.png" alt="Wootric" title="Wootric">
+</p>

--- a/source/includes/_install_android.md
+++ b/source/includes/_install_android.md
@@ -1,0 +1,138 @@
+# Installing Android SDK
+
+## Using Maven
+```xml
+<dependency>
+    <groupId>com.wootric</groupId>
+    <artifactId>wootric-sdk-android</artifactId>
+    <version>2.4.7</version>
+</dependency>
+```
+
+If you use Maven, you can include this library as a dependency.
+
+## Using Gradle
+```xml
+compile 'com.wootric:wootric-sdk-android:2.4.7'
+```
+
+ Add the following to your app’s `build.gradle` file, inside the dependencies section.
+
+# Presenting the survey
+WootricSDK task is to present a fully functional survey view with just a few lines of code.
+
+## Step 1. Add permissions
+```xml
+<uses-permission android:name="android.permission.INTERNET" />
+```
+Add the internet permissions to the `AndroidManifest.xml` file.
+
+
+## Step 2. Add ProGuard rules
+```ProGuard
+-keepattributes *Annotation*, Signature
+
+##== Wootric ==
+-keep class com.wootric.** { *; }
+
+##== Retrofit ==
+-keep class retrofit.** { *; }
+-keepclassmembernames interface * {
+    @retrofit.http.* <methods>;
+}
+```
+
+Add the following to your ProGuard rules file.
+
+## Step 3. Initialize Wootric
+```java
+import com.wootric.androidsdk.Wootric;
+
+// Inside your method
+Wootric wootric = Wootric.init(this, <YOUR_CLIENT_ID>, <YOUR_CLIENT_SECRET>, <YOUR_ACCOUNT_TOKEN>);
+
+// TODO: The current logged in user's email address.
+wootric.setEndUserEmail("nps@example.com");
+// TODO: The current logged in user's sign-up date as a Unix timestamp.
+wootric.setEndUserCreatedAt(1234567890);
+
+// Use only for testing
+wootric.setSurveyImmediately(true);
+
+wootric.survey();
+```
+First import the SDK into your Activity of choosing. Then configure the SDK with your client ID, secret and account token.
+
+Sign in at [wootric.com](https://www.wootric.com/) if you haven't already. If you just signed up on the Wootric homepage, you will be taken directly to an installation page. If you’re a returning visitor, click on the “Settings" button near the top right of the page. Navigate to the [Wootric Installation Guide](https://app.wootric.com/install) and you will see a unique **account_token** for you to use.
+
+The **client_id** and **client_secret** can also be found on your Settings page, on the [API section](https://app.wootric.com/account_settings/edit#!/api).
+
+To display the survey just use `wootric.survey();`. If the user is eligible (this check is built in the method) the SDK will show the survey.
+
+
+## Step 4. Customize the Survey
+
+> Comment out the line `wootric.setSurveyImmediately(true)` when you are ready for production. Alternatively, leave the line in the code for testing purposes or to survey the customer upon every visit to a view.
+
+```java
+import com.wootric.androidsdk.Wootric;
+import com.wootric.androidsdk.objects.WootricCustomThankYou;
+
+Wootric wootric = Wootric.init(this, "your_client_id", "your_client_secret", "NPS­-xxxxxxxx");
+wootric.setEndUserEmail("nps@example.com");
+wootric.setEndUserCreatedAt(1234567890);
+
+// Use only for testing
+wootric.setSurveyImmediately(true);
+
+// Customization
+WootricCustomThankYou customThankYou = new WootricCustomThankYou();
+customThankYou.setText("Merci!");
+
+wootric.setProductName("Wootric");
+wootric.setCustomThankYou(customThankYou);
+wootric.setLanguageCode("fr");
+
+wootric.survey();
+```
+
+This is an important step! [Customize](https://app.wootric.com/user_settings/edit#!/survey-nps) your survey with the name of your product or company. As needed, make changes to our trusted [survey](https://app.wootric.com/user_settings/edit#!/survey-nps) and [sampling](https://app.wootric.com/user_settings/edit#!/sampling) defaults. This values can modified from your app.
+
+<p align="center" >
+  <img src="https://cloud.githubusercontent.com/assets/1431421/17188297/0c761584-5402-11e6-9339-8af8f63125a5.png" alt="Wootric" title="Customization">
+  <img src="https://cloud.githubusercontent.com/assets/1431421/17188298/0c8dec22-5402-11e6-8925-020e777c36ba.png" alt="Wootric" title="Customization">
+</p>
+
+##Step 5. View your Responses Live!
+That's it! Once the WootricSDK is installed, eligible users will immediately start being surveyed.
+Depending on the traffic of your app, you could start to see responses within a few minutes.
+Responses will come in to your Wootric dash in real time.
+
+<aside class="notice">
+For a working implementation of the Android WootricSDK, try the demo app on our [Github repo](https://github.com/Wootric/WootricSDK-Android).
+</aside>
+
+
+### **No data yet?**
+Checkout the [Demo](https://demo.wootric.com/) dashboard with dummy data.
+
+<p align="center" >
+  <img src="https://cloud.githubusercontent.com/assets/1431421/17186433/d64cd56c-53fa-11e6-8add-2a141ff4f886.png" alt="Wootric" title="Demo">
+</p>
+
+### **I’d like to do some testing first. How do I ensure that the survey shows up on demand?**
+
+You can easily install Wootric in your development environment for testing. The SDK is
+already set up to show the survey immediately for testing purposes only.
+
+### Additional notes on WootricSDK placement:
+
+#### For apps with registered users:
+If your app has registered users, we recommend that you
+show the survey only on views that your logged in users will access to allow unique user
+identification.
+
+#### For ecommerce apps:
+If your app has a checkout flow, we recommend that you show the survey
+on views that won’t interrupt checkout. The most commonly used location is the transaction
+completion page.

--- a/source/includes/_install_ios.md
+++ b/source/includes/_install_ios.md
@@ -62,21 +62,22 @@ Drag WootricSDK.framework to the "Embedded Binaries" section of your Xcode proje
 ## Step 1. Initialize Wootric
 ``` objective_c
 #import <WootricSDK/WootricSDK.h>
-// In you view controller
 
+// Inside your method
 [Wootric configureWithClientID:<YOUR_CLIENT_ID> clientSecret:<YOUR_CLIENT_SECRET> accountToken:<YOUR_ACCOUNT_TOKEN>];
+
 // TODO: The current logged in user's email address.
 [Wootric setEndUserEmail:@"nps@example.com"];
 // TODO: The current logged in user's sign-up date as a Unix timestamp.
 [Wootric setEndUserCreatedAt:@1234567890];
 
+// Use only for testing
+[Wootric forceSurvey:YES];
+
 [Wootric showSurveyInViewController:<YOUR_VIEW_CONTROLLER>];
-
 ```
-
 ``` swift
-// In you view controller
-
+// Inside your method
 Wootric.configureWithClientID(<YOUR_CLIENT_ID>, clientSecret: <YOUR_CLIENT_SECRET>, accountToken: <YOUR_ACCOUNT_TOKEN>)
 
 // TODO: The current logged in user's email address.
@@ -84,14 +85,20 @@ Wootric.setEndUserEmail("nps@example.com")
 // TODO: The current logged in user's sign-up date as a Unix timestamp.
 Wootric.setEndUserCreatedAt(1234567890)
 
-Wootric.showSurveyInViewController(<YOUR_VIEW_CONTROLLER>)
+// Use only for testing
+Wootric.forceSurvey(true)
 
+Wootric.showSurveyInViewController(<YOUR_VIEW_CONTROLLER>)
 ```
-Once you are signed up on the Wootric homepage, you will be taken directly to an installation page. If you’re a returning visitor, sign in at [wootric.com](https://www.wootric.com/) and click on the “Settings" button near the top right of the page. Navigate to the [Wootric Installation Guide](https://app.wootric.com/install) and you will see a unique **account_token** for you to use.
+First import the SDK into your ViewController of choosing. Then configure the SDK with your client ID, secret and account token.
+
+Sign in at [wootric.com](https://www.wootric.com/) if you haven't already. If you just signed up on the Wootric homepage, you will be taken directly to an installation page. If you’re a returning visitor, click on the “Settings" button near the top right of the page. Navigate to the [Wootric Installation Guide](https://app.wootric.com/install) and you will see a unique **account_token** for you to use.
 
 The **client_id** and **client_secret** can be found on your account's settings [API section](https://app.wootric.com/account_settings/edit#!/api).
 
-<aside class="warning">
+To display the survey just use `showSurveyInViewController`. If the user is eligible (this check is built in the method) the SDK will show the survey.
+
+<aside class="notice">
 If you are using Swift, don't forget to import WootricSDK in your `Bridging-Header.h`
 </aside>
 
@@ -106,7 +113,8 @@ If you are using Swift, don't forget to import WootricSDK in your `Bridging-Head
 [Wootric configureWithClientID:@"your_client_id" clientSecret:@"your_client_secret" accountToken:@"NPS­-xxxxxxxx"];
 [Wootric setEndUserEmail:@"nps@example.com"];
 [Wootric setEndUserCreatedAt:@1234567890];
-// Fire immediately for testing
+
+// Use only for testing
 [Wootric forceSurvey:YES];
 
 // Customization
@@ -118,13 +126,11 @@ If you are using Swift, don't forget to import WootricSDK in your `Bridging-Head
 ```
 
 ```swift
-// In you view controller
-
 Wootric.configureWithClientID("your_client_id", clientSecret: "your_client_secret", accountToken: "NPS­-xxxxxxxx")
 Wootric.setEndUserEmail("nps@example.com")
 Wootric.setEndUserCreatedAt(1234567890)
 
-// Fire immediately for testing
+// Use only for testing
 Wootric.forceSurvey(true)
 
 // Customization
@@ -137,15 +143,28 @@ Wootric.showSurveyInViewController(self)
 
 This is an important step! [Customize](https://app.wootric.com/user_settings/edit#!/survey-nps) your survey with the name of your product or company. As needed, make changes to our trusted [survey](https://app.wootric.com/user_settings/edit#!/survey-nps) and [sampling](https://app.wootric.com/user_settings/edit#!/sampling) defaults. This values can modified from your app.
 
+<p align="center" >
+  <img src="https://cloud.githubusercontent.com/assets/1431421/17188297/0c761584-5402-11e6-9339-8af8f63125a5.png" alt="Wootric" title="Customization">
+  <img src="https://cloud.githubusercontent.com/assets/1431421/17188298/0c8dec22-5402-11e6-8925-020e777c36ba.png" alt="Wootric" title="Customization">
+</p>
+
 ## Step 3. View your Responses Live!
 That's it! Once the WootricSDK is installed, eligible users will immediately start being surveyed.
 Depending on the traffic of your app, you could start to see responses within a few minutes.
 Responses will come in to your Wootric dash in real time.
 
+<aside class="notice">
+For a working implementation of the iOS WootricSDK, try the demo app on our [Github repo](https://github.com/Wootric/WootricSDK-iOS).
+</aside>
+
 
 ### **No data yet?**
-We provide a link within your empty dashboard to a sample dash with dummy
-data.
+Checkout the [Demo](https://demo.wootric.com/) dashboard with dummy data.
+
+<p align="center" >
+  <img src="https://cloud.githubusercontent.com/assets/1431421/17186433/d64cd56c-53fa-11e6-8add-2a141ff4f886.png" alt="Wootric" title="Demo">
+</p>
+
 ### **I’d like to do some testing first. How do I ensure that the survey shows up on demand?**
 
 You can easily install Wootric in your development environment for testing. The SDK is

--- a/source/includes/_ios_custom_fields.md
+++ b/source/includes/_ios_custom_fields.md
@@ -16,7 +16,7 @@ While end user email is not required it is HIGHLY recommended to set it if possi
 ```swift
 Wootric.forceSurvey(<BOOL>)
 ```
-If forceSurvey is set to YES, the survey is displayed skipping eligibility check AND even if user was already surveyed. This is for test purposes only as it will display the survey every time and for every user.
+If forceSurvey is set to `true`, the survey is displayed skipping eligibility check AND even if user was already surveyed. This is for test purposes only as it will display the survey every time and for every user.
 
 ##surveyImmediately
 ```objective_c
@@ -25,7 +25,11 @@ If forceSurvey is set to YES, the survey is displayed skipping eligibility check
 ```swift
 Wootric.surveyImmediately(<BOOL>)
 ```
-If surveyImmediately is set to YES and user wasn't surveyed yet - eligibility check will return "true" and survey will be displayed. This shouldn't be used on production.
+If surveyImmediately is set to `true` and user wasn't surveyed yet - eligibility check will return `true` and survey will be displayed.
+
+<aside class="warning">
+This should not be used in production.
+</aside>
 
 ##setEndUserCreatedAt
 ```objective_c
@@ -34,7 +38,7 @@ If surveyImmediately is set to YES and user wasn't surveyed yet - eligibility ch
 ```swift
 Wootric.setEndUserCreatedAt(<UNIX Timestamp>)
 ```
-When creating a new end user for survey, it will set his/hers external creation date (so for example, date, when end user was created in your iOS application).
+When creating a new end user for survey, it will set the external creation date (so for example, date, when end user was created in your iOS application).
 This value is also used in eligibility check, to determine if end user should be surveyed.
 
 ##setFirstSurveyAfter
@@ -53,7 +57,7 @@ If not set, defaults to value from admin panel. Used to check if end user was cr
 ```swift
 Wootric.setEndUserProperties(<NSDICTIONARY>)
 ```
-Adds properties object to end user.
+End user properties can be provided as an `NSDictionary` object.
 
 ##setProductNameForEndUser
 ```objective_c
@@ -91,8 +95,3 @@ If you enable this setting, score and feedback text will be added as wootric_sco
 Wootric.skipFeedbackScreenForPromoter(<BOOL>)
 ```
 With this option enabled, promoters (score 9-10) will be taken directly to third (social share) screen, skipping the second (feedback) one.
-
-
-
-
-

--- a/source/includes/_ios_integrations.md
+++ b/source/includes/_ios_integrations.md
@@ -1,0 +1,54 @@
+#Segment Integration
+
+Wootric provides an integration for [Segment](https://segment.com/). The library can be found on [our Github](https://github.com/Wootric/segment-wootric-ios). 
+
+##Install with Cocoapods
+
+Segment-Wootric is available through [CocoaPods](http://cocoapods.org). To install
+it, simply add the following line to your `Podfile`:
+
+```ruby
+pod "Segment-Wootric"
+```
+
+##Usage
+```objective_c
+#import <Segment-Wootric/SegmentWootric.h>
+
+SEGAnalyticsConfiguration *config = [SEGAnalyticsConfiguration configurationWithWriteKey:@"YOUR_WRITE_KEY"];
+WTRWootricIntegrationFactory *wootricFactory = [WTRWootricIntegrationFactory instance];
+[config use:wootricFactory];
+[SEGAnalytics setupWithConfiguration:config];
+
+[WTRWootricIntegration showSurveyInViewController:<VIEW_CONTROLLER>];
+```
+```swift
+let config = SEGAnalyticsConfiguration.init(writeKey: "YOUR_WRITE_KEY")
+    
+let wootricFactory = WTRWootricIntegrationFactory.instance() as! WTRWootricIntegrationFactory
+config.use(wootricFactory)
+SEGAnalytics.setupWithConfiguration(config)
+
+WTRWootricIntegration.showSurveyInViewController(self)
+```
+First of all you need to provide values for account token, clientID and client secret in Segment's dashboard for Wootric integration, then import Segment-Wootric.
+
+Then init the Analytics with Wootric integration. Wootric integration responds to ```identify``` call, to read more about it, visit [Segment identify method documentation](https://segment.com/docs/libraries/ios/#identify).
+In identify call ```traits``` dictionary is set as ```endUserProperties``` in WootricSDK,  except keys ```email``` and ```createdAt``` which are set as ```endUserEmail``` and ```endUserCreatedAt``` respectively.
+
+For custom configuration you can use ```SEGWootric``` class instance, to get it, call:
+`[WTRWootricIntegration wootric]`
+For all available methods (being instace methods for SEGWootric instead of class methods) please refer to WootricSDK [docs](https://github.com/Wootric/WootricSDK-iOS).
+
+Finally to show the survey with `showSurveyInViewController`.
+
+<aside class="notice">
+If you are using Swift, don't forget to import 
+`#import <Segment-Wootric/SegmentWootric.h>` in your `Bridging-Header.h`
+</aside>
+
+#mParticle Integration
+
+Wootric provides an integration for [mParticle](http://mparticle.com/). 
+
+Instructions on how to setup the mParticle Apple SDK can be found on [mParticle's Github](https://github.com/mParticle/mparticle-apple-sdk/).

--- a/source/includes/_ios_samples.mdown
+++ b/source/includes/_ios_samples.mdown
@@ -1,0 +1,111 @@
+# Samples
+
+## Rate application on the App Store
+```objective_c
+#import <WootricSDK/WootricSDK.h>
+
+...
+
+[Wootric configureWithClientID:clientID clientSecret:clientSecret accountToken:accountToken];
+[Wootric setEndUserEmail:@"nps@example.com"];
+[Wootric setEndUserCreatedAt:@1234567890];
+
+// Replace YOUR_APP_ID with your application's id. 
+// e.g. https://itunes.apple.com/en/app/YOUR_APP_NAME/id123456789
+// The app id would 123456789
+NSURL *appStoreURL = [NSURL URLWithString:@"itms-apps://itunes.apple.com/WebObjects/MZStore.woa/wa/viewContentsUserReviews?id=YOUR_APP_ID&onlyLatestVersion=true&pageNumber=0&sortOrdering=1&type=Purple+Software"];
+
+// Uncomment to set ThankYouLink for all users
+//[Wootric setThankYouLinkWithText:@"Rate our app!" URL:appStoreURL];
+
+// Will set Link only for promoters
+[Wootric setPromoterThankYouLinkWithText:@"Rate our app!" URL:appStoreURL];
+
+// Will skip the Feedback view for Promoters
+[Wootric skipFeedbackScreenForPromoter:YES];
+
+// Uncomment for testing
+// NOTE: do not use on production
+//[Wootric forceSurvey:YES];
+
+[Wootric showSurveyInViewController:self];
+```
+
+```swift
+Wootric.configureWithClientID(clientID, clientSecret:clientSecret, accountToken:accountToken)
+Wootric.setEndUserEmail("nps@example.com")
+Wootric.setEndUserCreatedAt(1234567890)
+
+// Replace YOUR_APP_ID with your application's id.
+// e.g. https://itunes.apple.com/en/app/YOUR_APP_NAME/id123456789
+// The app id would 123456789
+let appStoreURL = NSURL(string: "itms-apps://itunes.apple.com/WebObjects/MZStore.woa/wa/viewContentsUserReviews?id=YOUR_APP_ID&onlyLatestVersion=true&pageNumber=0&sortOrdering=1&type=Purple+Software")
+
+// Uncomment to set ThankYouLink for all users
+// Wootric.setThankYouLinkWithText("Rate our app!", URL:appStoreURL);
+
+// Will set Link only for promoters
+Wootric.setPromoterThankYouLinkWithText("Rate our app!", URL:appStoreURL)
+
+// Will skip the Feedback view for Promoters
+Wootric.skipFeedbackScreenForPromoter(true)
+
+// Uncomment for testing
+// NOTE: do not use on production
+// Wootric.forceSurvey(true)
+
+Wootric.showSurveyInViewController(self)
+```
+
+You can set the last button to go to the App Store so users can rate your app.
+
+<p align="center" >
+  <img src="https://cloud.githubusercontent.com/assets/1431421/16994309/6da2c438-4e6c-11e6-91f1-c75fcac4d2e6.png" alt="Wootric" title="Wootric" style="height:400px;">
+</p>
+
+## Set End User Properties
+```objective_c
+#import <WootricSDK/WootricSDK.h>
+
+...
+
+[Wootric configureWithClientID:clientID clientSecret:clientSecret accountToken:accountToken];
+
+[Wootric setEndUserEmail:@"nps@example.com"];
+
+// Uncomment for testing
+// NOTE: do not use in production
+// [Wootric forceSurvey:YES];
+
+// Set end user's properties
+NSMutableDictionary *properties = [NSMutableDictionary new];
+[properties setObject:@"Wootric" forKey:@"company"];
+[properties setObject:@"awesome" forKey:@"type"];
+[properties setObject:@"iOS" forKey:@"os"];
+[Wootric setEndUserProperties:properties];
+
+[Wootric showSurveyInViewController:self];
+```
+
+```swift
+Wootric.configureWithClientID(clientID, clientSecret:clientSecret, accountToken:accountToken)
+    
+Wootric.setEndUserEmail("nps@example.com")
+
+// Uncomment for testing
+// NOTE: do not use in production
+// Wootric.forceSurvey(true)
+
+// Set end user's properties
+let properties: [String: String] = ["company" : "Wootric",
+									"type" : "awesome",
+                                    "os" :"iOS"]
+Wootric.setEndUserProperties(properties)
+
+Wootric.showSurveyInViewController(self)
+```
+Setting end user properties will help you segment and filter results.
+
+<p align="center" >
+  <img src="https://cloud.githubusercontent.com/assets/1431421/17043713/0b202224-4f7f-11e6-86cf-3193cfda998f.png" alt="Properties" title="Wootric">
+</p>

--- a/source/includes/_ios_troubleshooting.md
+++ b/source/includes/_ios_troubleshooting.md
@@ -1,0 +1,13 @@
+# Troubleshooting
+
+**Survey not showing up or is blank?**
+
+Check that client ID, client secret and account token are correct. Account token should have a "NPS-xxxxxxxx" format
+
+**I'm using `forceSurvey` but getting `User not eligible`**
+
+Check that Wootric Mobile Switch is enabled on your [Acount Settings](https://app.wootric.com/account_settings/edit?#!/account)
+
+<p align="center" >
+  <img src="https://cloud.githubusercontent.com/assets/1431421/17071952/562c86da-502a-11e6-8362-48aac99ced6a.png" alt="Wootric" title="Wootric">
+</p>

--- a/source/index.md
+++ b/source/index.md
@@ -9,7 +9,7 @@ Here is a list of the docs to integrate and use Wootric. It should not take more
 <br><br>
 * <a href="/ios" style="text-decoration:none;color:#000">Install Wootric using iOS SDK</a>
 <br><br>
-* <a href="https://github.com/Wootric/WootricSDK-Android/blob/master/README.md" style="text-decoration:none;color:#000">Install Wootric using Android SDK</a>
+* <a href="/android" style="text-decoration:none;color:#000">Install Wootric using Android SDK</a>
 <br><br>
 * <a href="/api" style="text-decoration:none;color:#000">REST API</a>
 <br><br>

--- a/source/ios.html.erb
+++ b/source/ios.html.erb
@@ -16,3 +16,6 @@ search: true
 <%= partial "includes/ios_view_config" %>
 <%= partial "includes/ios_custom_language" %>
 <%= partial "includes/ios_custom_thank_you" %>
+<%= partial "includes/ios_samples" %>
+<%= partial "includes/ios_troubleshooting" %>
+<%= partial "includes/ios_integrations" %>


### PR DESCRIPTION
-Adds Android documentation
-Adds Samples, Troubleshooting, Segment Integration
& mParticle Integration sections to iOS docs.

To test these changes and see how they would look with Slate,
I suggest following instructions of the README
on https://github.com/Wootric/slate/tree/wootric-master
but instead of git checkout wootric-master, try with
git checkout ds-ios-docs