### PR TITLE
Add time zone note

### DIFF
--- a/source/includes/_nps_summary.md
+++ b/source/includes/_nps_summary.md
@@ -50,6 +50,10 @@ This endpoint retrieves the NPS summary for the specified
 date range. If no date range is specified, the API returns NPS summary for
 the last month.
 
+<aside class="notice">
+The values returned by this endpoint depend on the Account's time zone setting.
+</aside>
+
 ### HTTP Request
 
 `GET https://api.wootric.com/v1/nps_summary`


### PR DESCRIPTION
Add a note on the Metrics section specifying
that the endpoint returns values according to
the time zone of the Account.

Trello: https://trello.com/c/7Qn3FVwH/1108-bug-fix-nps-summary-api