### PR TITLE
Fix German Informal language code

### DIFF
--- a/source/includes/_custom_language.md
+++ b/source/includes/_custom_language.md
@@ -33,7 +33,7 @@ English | EN
 Finnish | FI
 French | FR
 German | DE
-German -informal | DE-INFORMAL
+German -informal | DE_DE_X_INFORMAL
 Hungarian | HU
 Indonesian | ID
 Italian | IT


### PR DESCRIPTION
Changed code from DE-INFORMAL to DE_DE_X_INFORMAL

There is no trello card for this