### PR TITLE
Update language support for CES and CSAT

### DIFF
--- a/source/includes/_custom_language.md
+++ b/source/includes/_custom_language.md
@@ -20,7 +20,7 @@ To set a custom language add ```language``` parameter to ```wootricSettings``` a
 
 Please be advised, that custom messages and/or placeholder, takes precedence over language settings.
 
-Currently supported languages (with language codes):
+##Net Promoter Score (NPS) currently supports these languages (with language codes):
 
 Language | Code
 -------- | ----
@@ -50,3 +50,20 @@ Spanish - Mexico | ES_MX
 Swedish | SV
 Turkish | TR
 Vietnamese | VN
+
+##Customer Effort Score (CES) currently supports these languages (with language codes):
+
+Language | Code
+-------- | ----
+English | EN
+Spanish | ES
+Spanish - Mexico | ES_MX
+
+##Customer Satisfaction (CSAT) currently supports these languages (with language codes):
+
+Language | Code
+-------- | ----
+English | EN
+Spanish | ES
+Spanish - Mexico | ES_MX
+German | DE


### PR DESCRIPTION
Update language support for CES and CSAT.

Trello: https://trello.com/c/6j7snpwC/1178-5-update-docs-with-what-languages-we-support-for-ces-and-csat-and-specifically-label-our-current-language-coverage-as-nps-only