### PR TITLE
Add Latvian language

### DIFF
--- a/source/includes/_custom_language.md
+++ b/source/includes/_custom_language.md
@@ -38,6 +38,7 @@ Hungarian | HU
 Indonesian | ID
 Italian | IT
 Japanese | JA
+Latvian | LV
 Lithuanian | LT
 Norwegian | NO
 Polish | PL


### PR DESCRIPTION
Adds Latvian language

trello: https://trello.com/c/IrIBbZ3h/1322-please-add-latvian-language-translations-here-https-docs-google-com-spreadsheets-d-1mqdlohmfkaqey3fh73tzo6modepgyd-p0wlcegqglki-