### PR TITLE
Add Google Tag Manager to every page

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -38,9 +38,25 @@ under the License.
         });
       </script>
     <% end %>
+
+    <!-- Google Tag Manager -->
+    <script>
+      (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+      'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+      })(window,document,'script','dataLayer','GTM-PF46GT3');
+    </script>
+    <!-- End Google Tag Manager -->
   </head>
 
   <body class="<%= page_classes %>">
+    <!-- Google Tag Manager (noscript) -->
+    <noscript>
+      <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-PF46GT3" height="0" width="0" style="display:none;visibility:hidden"></iframe>
+    </noscript>
+    <!-- End Google Tag Manager (noscript) -->
+
     <a href="#" id="nav-button">
       <span>
         NAV


### PR DESCRIPTION
Add Google Tag Manager to every page.

Testing:
- Check Chrome console for a failed GTM request. GTM only works in prod.

Trello: https://trello.com/c/FmNiRWdV/1395-add-gtm-to-docs-wootric-com-all-pages