### PR TITLE
Add Korean language

### DIFF
--- a/source/includes/_custom_language.md
+++ b/source/includes/_custom_language.md
@@ -39,6 +39,7 @@ Hungarian | HU
 Indonesian | ID
 Italian | IT
 Japanese | JA
+Korean | KO
 Latvian | LV
 Lithuanian | LT
 Norwegian | NO
@@ -59,6 +60,7 @@ Language | Code
 -------- | ----
 English | EN
 Estonian | ET
+Korean | KO
 Spanish | ES
 Spanish - Mexico | ES_MX
 
@@ -68,6 +70,7 @@ Language | Code
 -------- | ----
 English | EN
 Estonian | ET
+Korean | KO
 Spanish | ES
 Spanish - Mexico | ES_MX
 German | DE


### PR DESCRIPTION
Adds korean language code to NPS, CES & CSAT

Trello
https://trello.com/c/5CcfFRZ3/1696-add-korean-language-to-all-surveys