### PR TITLE
Remove beacon.js references in favor of wootric-sdk.js

### DIFF
--- a/source/includes/_install_js_intro.md
+++ b/source/includes/_install_js_intro.md
@@ -80,7 +80,7 @@ snippet.
       account_token: 'NPS-XXXXXXXX'
   };
 </script>
-<script type="text/javascript" src="https://disutgh7q0ncc.cloudfront.net/beacon.js" async onload="WootricSurvey.run(wootricSettings)"></script>
+<script type="text/javascript" src="https://cdn.wootric.com/wootric-sdk.js" async onload="WootricSurvey.run(wootricSettings)"></script>
 ```
 
 We support HTML5 async attribute to load our snippet.

--- a/source/includes/_install_js_spa_intro.md
+++ b/source/includes/_install_js_spa_intro.md
@@ -12,7 +12,7 @@
     account_token: 'NPS-XXXX' //TODO:replace it with your account token       
   };    
 </script>
-<script type="text/javascript" src="https://disutgh7q0ncc.cloudfront.net/beacon.js"></script>
+<script type="text/javascript" src="https://cdn.wootric.com/wootric-sdk.js"></script>
 <script>window.wootric("run")</script>
 <!-- end Wootric code -->
 ```
@@ -51,7 +51,7 @@ A way to load the Wootric snippet in a factory file so it can be fired in a sing
 
 ## Angular Step 2. Load Wootric JS SDK
 ```
-<script type="text/javascript" src="https://disutgh7q0ncc.cloudfront.net/beacon.js"></script>
+<script type="text/javascript" src="https://cdn.wootric.com/wootric-sdk.js"></script>
 ```
 Add this script tag to the file where you load all other 3rd party scripts
 ## Angular Step 3. Using the factory in your controller


### PR DESCRIPTION
- Change beacon.js to wootric-sdk.js

Trello: https://trello.com/c/8nc75tux/2851-2-custom-domains-for-cloudfront-on-the-beacon-buckets