### PR TITLE
Update Email API Docs

### DIFF
--- a/source/includes/_email_survey.md
+++ b/source/includes/_email_survey.md
@@ -50,6 +50,7 @@ curl "https://api.wootric.com/v1/email_survey" \
   -d "emails[]=john@example.com" \
   -d "emails[]=martin@example.com" \
   -d "survey_immediately=true" \
+  -d "survey_settings[logo_url]=https://company_logo_url.com" \
   -d "survey_settings[custom_messages][followup_text]=Thank you!" \
   -d "end_user[properties][campaign_name]=Campaign Name&end_user[properties][campaign_type]=Campaign Type" \
   -d "subject=Would you mind sharing your thoughts about our {{service}}?" \
@@ -72,6 +73,7 @@ curl "https://api.wootric.com/v1/email_survey" \
 Param | Type | Description
 ----- | ---- | ------------
 language | String
+logo_url | String
 audience_text | String
 product_name | String
 custom_messages | Hash | See **custom_messages** parameters below


### PR DESCRIPTION
- Add logo_url parameter in the email api docs

Trello: https://trello.com/c/2pHmBEAi/3010-add-logo-parameter-to-email-template-support-does-not-need-to-be-in-the-downloads-but-needs-to-be-a-custom-setting-we-can-offer