### PR TITLE
Remove secret from docs & add new methods

### DIFF
--- a/source/includes/_install_ios.md
+++ b/source/includes/_install_ios.md
@@ -64,7 +64,7 @@ Drag WootricSDK.framework to the "Embedded Binaries" section of your Xcode proje
 #import <WootricSDK/WootricSDK.h>
 
 // Inside your method
-[Wootric configureWithClientID:<YOUR_CLIENT_ID> clientSecret:<YOUR_CLIENT_SECRET> accountToken:<YOUR_ACCOUNT_TOKEN>];
+[Wootric configureWithClientID:<YOUR_CLIENT_ID> accountToken:<YOUR_ACCOUNT_TOKEN>];
 
 // TODO: Required to uniquely identify a user. Email is recommended but this can be any unique identifier.
 [Wootric setEndUserEmail:@"nps@example.com"];
@@ -78,7 +78,7 @@ Drag WootricSDK.framework to the "Embedded Binaries" section of your Xcode proje
 ```
 ``` swift
 // Inside your method
-Wootric.configureWithClientID(<YOUR_CLIENT_ID>, clientSecret: <YOUR_CLIENT_SECRET>, accountToken: <YOUR_ACCOUNT_TOKEN>)
+Wootric.configureWithClientID(<YOUR_CLIENT_ID>, accountToken: <YOUR_ACCOUNT_TOKEN>)
 
 // TODO: Required to uniquely identify a user. Email is recommended but this can be any unique identifier.
 Wootric.setEndUserEmail("nps@example.com")
@@ -92,7 +92,7 @@ Wootric.showSurveyInViewController(<YOUR_VIEW_CONTROLLER>)
 ```
 ``` swift_three
 // Inside your method
-Wootric.configure(withClientID: <YOUR_CLIENT_ID>, clientSecret:<YOUR_CLIENT_SECRET>,, accountToken:<YOUR_ACCOUNT_TOKEN>)
+Wootric.configure(withClientID: <YOUR_CLIENT_ID> , accountToken:<YOUR_ACCOUNT_TOKEN>)
 
 // TODO: Required to uniquely identify a user. Email is recommended but this can be any unique identifier.
 Wootric.setEndUserEmail("nps@example.com")
@@ -104,11 +104,11 @@ Wootric.forceSurvey(true)
 
 Wootric.showSurvey(in: <YOUR_VIEW_CONTROLLER>)
 ```
-First import the SDK into your ViewController of choosing. Then configure the SDK with your client ID, secret and account token.
+First import the SDK into your ViewController of choosing. Then configure the SDK with your client ID and account token.
 
 Sign in at [wootric.com](https://www.wootric.com/) if you haven't already. If you just signed up on the Wootric homepage, you will be taken directly to an installation page. If you’re a returning visitor, click on the “Settings" button near the top right of the page. Navigate to the [Wootric Installation Guide](https://app.wootric.com/install) and you will see a unique **account_token** for you to use.
 
-The **client_id** and **client_secret** can be found on your account's settings [API section](https://app.wootric.com/account_settings/edit#!/api).
+The **client_id** can be found on your account's settings [API section](https://app.wootric.com/account_settings/edit#!/api).
 
 To display the survey just use `showSurveyInViewController`. If the user is eligible (this check is built in the method) the SDK will show the survey.
 
@@ -124,7 +124,7 @@ If you are using Swift, don't forget to import WootricSDK in your `Bridging-Head
 ```objective_c
 #import <WootricSDK/WootricSDK.h>
 
-[Wootric configureWithClientID:@"your_client_id" clientSecret:@"your_client_secret" accountToken:@"NPS­-xxxxxxxx"];
+[Wootric configureWithClientID:@"your_client_id" accountToken:@"NPS­-xxxxxxxx"];
 [Wootric setEndUserEmail:@"nps@example.com"];
 [Wootric setEndUserCreatedAt:@1234567890];
 
@@ -139,7 +139,7 @@ If you are using Swift, don't forget to import WootricSDK in your `Bridging-Head
 [Wootric showSurveyInViewController:self];
 ```
 ```swift
-Wootric.configureWithClientID("your_client_id", clientSecret: "your_client_secret", accountToken: "NPS­-xxxxxxxx")
+Wootric.configureWithClientID("your_client_id", accountToken: "NPS­-xxxxxxxx")
 Wootric.setEndUserEmail("nps@example.com")
 Wootric.setEndUserCreatedAt(1234567890)
 
@@ -154,7 +154,7 @@ Wootric.setCustomLanguage("fr")
 Wootric.showSurveyInViewController(self)
 ```
 ```swift_three
-Wootric.configure(withClientID:"your_client_id", clientSecret: "your_client_secret", accountToken: "NPS­-xxxxxxxx")
+Wootric.configure(withClientID:"your_client_id", accountToken: "NPS­-xxxxxxxx")
 Wootric.setEndUserEmail("nps@example.com")
 Wootric.setEndUserCreatedAt(1234567890)
 

--- a/source/includes/_ios_custom_fields.md
+++ b/source/includes/_ios_custom_fields.md
@@ -137,3 +137,51 @@ Wootric.skipFeedbackScreenForPromoter(<BOOL>)
 Wootric.skipFeedbackScreen(forPromoter: true)
 ```
 With this option enabled, promoters (score 9-10) will be taken directly to third (social share) screen, skipping the second (feedback) one.
+
+## showOptOut
+```objective_c
+[Wootric forceSurvey:<BOOL>];
+```
+```swift
+Wootric.showOptOut(true)
+```
+```swift_three
+Wootric.showOptOut(true)
+```
+If showOptOut is set to YES, it will show an option for the end user to opt out of being surveyed. Default value is NO.
+
+## setLogLevelNone
+```objective_c
+[Wootric setLogLevelNone];
+```
+```swift
+Wootric.setLogLevelNone()
+```
+```swift_three
+Wootric.setLogLevelNone()
+```
+Set WTRLogger level to None i.e. it won't show any log from the WootricSDK.
+
+## setLogLevelError
+```objective_c
+[Wootric setLogLevelError];
+```
+```swift
+Wootric.setLogLevelError()
+```
+```swift_three
+Wootric.setLogLevelError()
+```
+Set WTRLogger level to Error i.e. it will only show error logs from the WootricSDK.
+
+## setLogLevelVerbose
+```objective_c
+[Wootric setLogLevelVerbose];
+```
+```swift
+Wootric.setLogLevelVerbose()
+```
+```swift_three
+Wootric.setLogLevelVerbose()
+```
+Set WTRLogger level to Verbose i.e. it will show all logs from the WootricSDK.

--- a/source/includes/_ios_integrations.md
+++ b/source/includes/_ios_integrations.md
@@ -40,7 +40,7 @@ SEGAnalytics.setup(with: config)
 
 WTRWootricIntegration.showSurvey(in: self)
 ```
-First of all you need to provide values for account token, clientID and client secret in Segment's dashboard for Wootric integration, then import Segment-Wootric.
+First of all you need to provide values for account token and clientID in Segment's dashboard for Wootric integration, then import Segment-Wootric.
 
 Then init the Analytics with Wootric integration. Wootric integration responds to ```identify``` call, to read more about it, visit [Segment identify method documentation](https://segment.com/docs/libraries/ios/#identify).
 In identify call ```traits``` dictionary is set as ```endUserProperties``` in WootricSDK,  except keys ```email``` and ```createdAt``` which are set as ```endUserEmail``` and ```endUserCreatedAt``` respectively.

--- a/source/includes/_ios_samples.mdown
+++ b/source/includes/_ios_samples.mdown
@@ -6,7 +6,7 @@
 
 ...
 
-[Wootric configureWithClientID:clientID clientSecret:clientSecret accountToken:accountToken];
+[Wootric configureWithClientID:clientID accountToken:accountToken];
 [Wootric setEndUserEmail:@"nps@example.com"];
 [Wootric setEndUserCreatedAt:@1234567890];
 
@@ -31,7 +31,7 @@ NSURL *appStoreURL = [NSURL URLWithString:@"itms-apps://itunes.apple.com/WebObje
 [Wootric showSurveyInViewController:self];
 ```
 ```swift
-Wootric.configureWithClientID(clientID, clientSecret:clientSecret, accountToken:accountToken)
+Wootric.configureWithClientID(clientID, accountToken:accountToken)
 Wootric.setEndUserEmail("nps@example.com")
 Wootric.setEndUserCreatedAt(1234567890)
 
@@ -56,7 +56,7 @@ Wootric.skipFeedbackScreenForPromoter(true)
 Wootric.showSurveyInViewController(self)
 ```
 ```swift_three
-Wootric.configure(withClientID: clientID, clientSecret:clientSecret, accountToken:accountToken)
+Wootric.configure(withClientID: clientID, accountToken:accountToken)
 Wootric.setEndUserEmail("nps@example.com")
 Wootric.setEndUserCreatedAt(1234567890)
 
@@ -93,7 +93,7 @@ You can set the last button to go to the App Store so users can rate your app.
 
 ...
 
-[Wootric configureWithClientID:clientID clientSecret:clientSecret accountToken:accountToken];
+[Wootric configureWithClientID:clientID accountToken:accountToken];
 
 [Wootric setEndUserEmail:@"nps@example.com"];
 
@@ -116,7 +116,7 @@ NSMutableDictionary *properties = [NSMutableDictionary new];
 [Wootric showSurveyInViewController:self];
 ```
 ```swift
-Wootric.configureWithClientID(clientID, clientSecret:clientSecret, accountToken:accountToken)
+Wootric.configureWithClientID(clientID, accountToken:accountToken)
     
 Wootric.setEndUserEmail("nps@example.com")
 
@@ -139,7 +139,7 @@ Wootric.setEndUserProperties(properties)
 Wootric.showSurveyInViewController(self)
 ```
 ```swift_three
-Wootric.configure(withClientID: clientID, clientSecret:clientSecret, accountToken:accountToken)
+Wootric.configure(withClientID: clientID, accountToken:accountToken)
     
 Wootric.setEndUserEmail("nps@example.com")
 

--- a/source/includes/_ios_troubleshooting.md
+++ b/source/includes/_ios_troubleshooting.md
@@ -2,7 +2,7 @@
 
 **Survey not showing up or is blank?**
 
-Check that client ID, client secret and account token are correct. Account token should have a "NPS-xxxxxxxx" format
+Check that client ID and account token are correct. Account token should have a "NPS-xxxxxxxx" format
 
 **I'm using `forceSurvey` but getting `User not eligible`**
 


### PR DESCRIPTION
Client secret is no longer needed in the SDK. Also, added documentation for
new methods.

## Trello
https://trello.com/c/qc8lu3Xf/16-2-gdpr-ios-sdk