### PR TITLE
Update DOC with Swedish in CES and CSAT

### DIFF
--- a/source/includes/_custom_language.md
+++ b/source/includes/_custom_language.md
@@ -76,6 +76,7 @@ Portuguese | PT
 Romanian | RO
 Spanish | ES
 Spanish - Mexico | ES_MX
+Swedish | SV
 Ukrainian | UK
 
 ##Customer Satisfaction (CSAT) currently supports these languages (with language codes):
@@ -97,4 +98,5 @@ Portuguese | PT
 Romanian | RO
 Spanish | ES
 Spanish - Mexico | ES_MX
+Swedish | SV
 Ukrainian | UK


### PR DESCRIPTION
Changes: Add `swedish` Language/Code to list of CES and CSAT support section.

Trello: https://trello.com/c/wI1aOZRV/3565-add-swedish-for-csat-and-ces-translations-offered-by-our-customer

Note: This PR works with another PR from wootric https://github.com/Wootric/wootric/pull/2243 and survey https://github.com/Wootric/survey/pull/226