### PR TITLE
Change Help Button Text

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -77,7 +77,7 @@ under the License.
         </div>
       <% end %>
       <div class="wootric-doc-topbar__space"></div>
-      <div class="wootric-doc-topbar__help-link"><a href="http://help.wootric.com" target="_blank">Help</a></div>
+      <div class="wootric-doc-topbar__help-link"><a href="http://help.wootric.com" target="_blank"><i data-icon="?"></i> help center</a></div>
       <div class="wootric-doc-topbar__sign">
         <a class="wootric-doc-topbar__sign-in" href="https://app.wootric.com/sign_in">sign in</a>
         <a class="wootric-doc-topbar__sign-up" href="https://app.wootric.com/sign_up">sign up free</a>

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -399,10 +399,36 @@ html, body {
       @include transition(ease-in-out 0.1s);
       color: $darker-gray;
       text-decoration: none;
+
+      [data-icon]:before {
+        @include transition(ease-in-out 0.1s);
+        background: #605A5C;
+        border-radius: 100%;
+        color: #ffffff;
+        content: attr(data-icon);
+        display: inline-block;
+        font-family: Arial Black, Helvetica, Arial, sans-serif;
+        font-weight: bold;
+        font-size: 12px;
+        font-style: normal;
+        height: 10px;
+        line-height: 14px;
+        margin-right: 3px;
+        padding: 0px 2px 3px 1px;
+        position: relative;
+        text-align: center;
+        top: -1px;
+        width: 10px;
+      }
     }
 
     a:hover {
       color: $wootric-green;
+
+      [data-icon]:before {
+        background: $wootric-green;
+        color: #ffffff;
+      }
     }
   }
 

--- a/source/stylesheets/variables.scss
+++ b/source/stylesheets/variables.scss
@@ -102,7 +102,7 @@ $phone-width: $tablet-width - $nav-width; // min width before reverting to mobil
 }
 
 %nav-font {
-  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-family: "Lato", "Helvetica Neue", Helvetica, Arial, sans-serif;
 }
 
 


### PR DESCRIPTION
# Task
- Change help button text from `Help` to `Help Center`
- Add icon to `Help Center` button
<img width="1280" alt="screen shot 2018-09-18 at 11 09 39" src="https://user-images.githubusercontent.com/16229024/45708614-c145b800-bb36-11e8-85e8-93507d275e7a.png">


# Trello card: https://trello.com/c/CbQuoRKs