### PR TITLE
Add Chinese CES and CSAT translations

### DIFF
--- a/source/includes/_custom_language.md
+++ b/source/includes/_custom_language.md
@@ -62,6 +62,8 @@ Vietnamese | VN
 Language | Code
 -------- | ----
 Bulgarian | BG
+Chinese (Simplified) | CN_S
+Chinese (Traditional) | CN_T
 Danish | DA
 Dutch | NL
 English | EN
@@ -84,6 +86,8 @@ Ukrainian | UK
 Language | Code
 -------- | ----
 Bulgarian | BG
+Chinese (Simplified) | CN_S
+Chinese (Traditional) | CN_T
 Dutch | NL
 English | EN
 Estonian | ET


### PR DESCRIPTION
Changes: Add `Chinese Simplified` and `Chinese Traditional` Language (Code) to list of CES and CSAT support section.

Trello: https://trello.com/c/PjI4kYZj/3649-add-language-updates-for-chinese-norwegian-and-french-for-surveys

Note: This PR works with another PR from wootric https://github.com/Wootric/wootric/pull/2377 and survey https://github.com/Wootric/survey/pull/239