### PR TITLE
Update Doc for Vietnamese with CES

### DIFF
--- a/source/includes/_custom_language.md
+++ b/source/includes/_custom_language.md
@@ -80,6 +80,7 @@ Spanish | ES
 Spanish - Mexico | ES_MX
 Swedish | SV
 Ukrainian | UK
+Vietnamese | VN
 
 ##Customer Satisfaction (CSAT) currently supports these languages (with language codes):
 


### PR DESCRIPTION
Changes: Add Vietnamese language to CES section.

Docs: https://docs.google.com/spreadsheets/d/1JsDd4WKwuyFwvIcXXtA-4LpvuO4dlnRceHyqqMhM-Y4/edit#gid=0

Trello: https://trello.com/c/JlkzKDOu/4284-add-vietnamese-ces-translation

Note: This PR works with another PR from wootric https://github.com/Wootric/wootric/pull/2424 and survey https://github.com/Wootric/survey/pull/243