### PR TITLE
Fix wootric.run typo

### DIFF
--- a/source/includes/_install_js_intro.md
+++ b/source/includes/_install_js_intro.md
@@ -49,7 +49,7 @@ This is an important step! [Customize](https://app.wootric.com/user_settings/edi
     account_token: 'NPS­xxxxxxxx' };
 
   //Request a survey
-  window.wootric('run';)
+  window.wootric('run');
 </script>
 <!--­­ end Wootric code ­­-->
 ```


### PR DESCRIPTION
Changes: There's typo in install step of http://docs.wootric.com/javascript/#step-3--view-your-responses-live.
```
//Currently
window.wootric('run')
//Fix
window.wootric('run';)
```

Trello: https://trello.com/c/MjieDesR/4597-windowrun-type-in-docs