### PR TITLE
Expose event_name

### DIFF
--- a/source/includes/_install_js_intro.md
+++ b/source/includes/_install_js_intro.md
@@ -103,6 +103,7 @@ twitter_account | null | A Twitter link you can use to tag your account anytime 
 wootric_close_position | left | The position of the close button of your survey.
 wootric_recommend_target | depends on the language | Your audience.
 ask_permission_to_share_feedback | false | Ask your end users if they wish to be contacted after leaving written feedback.
+event_name | null | Set an event name here to be used with Wootric's Targeted Sampling.
 
 ### The code example generates the following survey:
 


### PR DESCRIPTION
- Add event_name to the Wootric Settings Object section. I'm not going into too much detail since docs for Targeted Sampling should be created with the help of the entire product team.

# Trello

https://trello.com/c/1GEsKn3Z/5403-add-to-docs-how-to-pass-events-via-the-js-for-use-in-targeted-sampling