### PR TITLE
Add comma character to properties example

### DIFF
--- a/source/includes/_custom_fields.md
+++ b/source/includes/_custom_fields.md
@@ -19,9 +19,9 @@ window.wootricSettings = {
   product_name: 'Wootric', // TODO: The name of the product or service.
   account_token: 'NPS­xxxxxxxx',
   properties:{
-    role:'manager',// TODO: The current user's role.
-    pricing_plan:'Enterprise'// TODO: The current user's pricing plan.
-    total_purchase_amount: 12 // Integer representing the user's total purchases with the key suffixed with "_amount"
+    role:'manager', // TODO: The current user's role.
+    pricing_plan:'Enterprise', // TODO: The current user's pricing plan.
+    total_purchase_amount: 12, // Integer representing the user's total purchases with the key suffixed with "_amount"
     last_order_date: 1350466020 // Integer representing the date (Unix timestamp format) of the user's last order with the key suffixed with "_date"
   }
 };

--- a/source/includes/_custom_language.md
+++ b/source/includes/_custom_language.md
@@ -9,7 +9,8 @@ window.wootricSettings = {
   created_at: 1234567890,
   product_name: 'Wootric',
   account_token: 'NPS­xxxxxxxx',
-  language: 'XX' };
+  language: 'XX'
+};
 </script>
 ....//The rest of the widget...
 <!--­­ end Wootric code --­­>


### PR DESCRIPTION
There's a syntax error in our help docs. This will fix it.

Minor:

Adjust indentation of another example inside our docs.

Trello:

https://trello.com/c/wzcnC5JY/5740-fix-syntax-error-in-docs