### PR TITLE
Add Targeted Sampling section

### DIFF
--- a/source/includes/_ios_targeted_sampling.md
+++ b/source/includes/_ios_targeted_sampling.md
@@ -1,0 +1,53 @@
+# Targeted Sampling
+
+```objective_c
+NSString *clientID = @"CLIENT_ID";
+NSString *accountToken = @"ACCOUNT_TOKEN";
+
+[Wootric configureWithClientID:clientID accountToken:accountToken];
+[Wootric setEndUserEmail:@"nps@example.com"];
+[Wootric setEndUserCreatedAt:@1234567890];
+[Wootric setEndUserProperties:@{ @"Example_string": @"pro_plan", @"Example_value": @12}];
+
+[Wootric showSurveyInViewController:self event:@"On Purchase Event"];
+```
+```swift
+let clientID = "CLIENT_ID"
+let accountToken = "ACCOUNT_TOKEN"
+
+Wootric.configure(withClientID: clientID, accountToken: accountToken)
+Wootric.endUserEmail = "nps@example.com"
+Wootric.endUserCreatedAt = NSNumber(value: 1234567890)
+Wootric.endUserProperties = [
+  "Example_string": "pro_plan",
+  "Example_value": NSNumber(value: 12)
+]
+
+Wootric.showSurvey(inViewController: self, event: "On Purchase Event")
+```
+```swift_three
+let clientID = "CLIENT_ID"
+let accountToken = "ACCOUNT_TOKEN"
+
+Wootric.configure(withClientID: clientID, accountToken: accountToken)
+Wootric.endUserEmail = "nps@example.com"
+Wootric.endUserCreatedAt = NSNumber(value: 1234567890)
+Wootric.endUserProperties = [
+  "Example_string": "pro_plan",
+  "Example_value": NSNumber(value: 12)
+]
+
+Wootric.showSurvey(inViewController: self, event: "On Purchase Event")
+```
+
+You can trigger surveys based on an end-user's property, an event that you might be tracking in your app or a combination of both. You must configure the rules that trigger these surveys inside Wootric Settings Panel.
+
+To set the properties for the end user you can pass an dictionary to
+the `setEndUserProperties` method.
+
+To trigger a survey with an event you ned to use
+`showSurveyInViewController:event:`.
+
+
+For more information on how to configure Targeted Sampling, visit
+[How do I setup targeted sampling for in-app surveys?](http://help.wootric.com/en/articles/3472284-how-do-i-setup-targeted-sampling-for-in-app-surveys)

--- a/source/ios.html.erb
+++ b/source/ios.html.erb
@@ -14,6 +14,7 @@ search: true
 <%= partial "includes/install_ios" %>
 <%= partial "includes/ios_custom_fields" %>
 <%= partial "includes/ios_view_config" %>
+<%= partial "includes/ios_targeted_sampling" %>
 <%= partial "includes/ios_delegate" %>
 <%= partial "includes/ios_custom_language" %>
 <%= partial "includes/ios_custom_thank_you" %>


### PR DESCRIPTION
Add new section explaining how to use Targeted Sampling in iOS.

## Changes

- Add _ios_targeted_sampling.md file

## Test

1. Pull this branch
2. Run the docs with `bundle exec middleman server`
3. New section should be at http://localhost:4567/ios?objective_c#targeted-sampling