### PR TITLE
Add Android Targeted Sampling section

### DIFF
--- a/source/android.html.erb
+++ b/source/android.html.erb
@@ -10,6 +10,7 @@ search: true
 <%= partial "includes/android_custom_fields" %>
 <%= partial "includes/android_custom_language" %>
 <%= partial "includes/android_custom_thank_you" %>
+<%= partial "includes/android_targeted_sampling" %>
 <%= partial "includes/android_callbacks" %>
 <%= partial "includes/android_samples" %>
 <%= partial "includes/android_troubleshooting" %>

--- a/source/includes/_android_targeted_sampling.md
+++ b/source/includes/_android_targeted_sampling.md
@@ -1,0 +1,25 @@
+# Targeted Sampling
+
+```java
+Wootric wootric = Wootric.init(this, CLIENT_ID, ACCOUNT_TOKEN);
+wootric.setEndUserEmail("nps@example.com");
+wootric.setEndUserCreatedAt(1234567890);
+
+HashMap<String, String> properties = new HashMap();
+properties.put("Example_string", "pro_plan");
+properties.put("Example_value", "12");
+wootric.setProperties(properties);
+        
+wootric.survey("On Purchase Event");
+```
+
+You can trigger surveys based on an end-user's property, an event that you might be tracking in your app or a combination of both. You must configure the rules that trigger these surveys inside Wootric Settings Panel.
+
+To set the properties for the end user you can pass a HashMap to
+the `setProperties` method.
+
+To trigger a survey with an event you ned to use `survey(event:)`.
+
+
+For more information on how to configure Targeted Sampling, visit
+[How do I setup targeted sampling for in-app surveys?](http://help.wootric.com/en/articles/3472284-how-do-i-setup-targeted-sampling-for-in-app-surveys)

--- a/source/includes/_install_android.md
+++ b/source/includes/_install_android.md
@@ -5,7 +5,7 @@
 <dependency>
     <groupId>com.wootric</groupId>
     <artifactId>wootric-sdk-android</artifactId>
-    <version>2.8.0</version>
+    <version>2.15.0</version>
 </dependency>
 ```
 
@@ -13,7 +13,7 @@ If you use Maven, you can include this library as a dependency.
 
 ## Using Gradle
 ```xml
-compile 'com.wootric:wootric-sdk-android:2.8.0'
+compile 'com.wootric:wootric-sdk-android:*'
 ```
 
  Add the following to your app’s `build.gradle` file, inside the dependencies section.

--- a/source/includes/_ios_targeted_sampling.md
+++ b/source/includes/_ios_targeted_sampling.md
@@ -42,7 +42,7 @@ Wootric.showSurvey(inViewController: self, event: "On Purchase Event")
 
 You can trigger surveys based on an end-user's property, an event that you might be tracking in your app or a combination of both. You must configure the rules that trigger these surveys inside Wootric Settings Panel.
 
-To set the properties for the end user you can pass an dictionary to
+To set the properties for the end user you can pass a dictionary to
 the `setEndUserProperties` method.
 
 To trigger a survey with an event you ned to use


### PR DESCRIPTION
Add new section explaining how to use Targeted Sampling in Android.

## Changes

- Add source/includes/_android_targeted_sampling.md
- Add section to sidebar

### Minor

- Fix Android version
- Fix iOS typo