### PR TITLE
Remove access token as query param

### DIFF
--- a/source/includes/_api_index.md
+++ b/source/includes/_api_index.md
@@ -103,10 +103,6 @@ Wootric expects the  token to be included in all API requests regardless of gran
 
 `curl -H "Authorization: Bearer <youraccesstoken>" https://api.wootric.com/v1/end_users`
 
-Token can be sent as query parameters as well but we **do not recommend** it for security purposes. For example
-
-`https://api.wootric.com/v1/end_users?access_token=myaccesstoken`
-
 Access tokens expire 2 hours after creation. New access_token can be obtained using refresh tokens as detailed in the cURL example to the right.
 
 <aside class="notice">

--- a/source/includes/_declines.md
+++ b/source/includes/_declines.md
@@ -18,10 +18,6 @@ end_user.properties | hash | The end user properties at the moment the survey wa
 ## Get All Declines
 
 ```shell
-curl "https://api.wootric.com/v1/declines?access_token=myaccesstoken"
-
-or
-
 curl -H "Authorization: Bearer myaccesstoken" "https://api.wootric.com/v1/declines"
 ```
 
@@ -90,10 +86,6 @@ We recommend to iterate using `created` parameter if you need to get more data t
 ## Get All End User's Declines
 
 ```shell
-curl "https://api.wootric.com/v1/end_users/1/declines?access_token=myaccesstoken"
-
-or
-
 curl -H "Authorization: Bearer myaccesstoken" "https://api.wootric.com/v1/end_users/1/declines"
 ```
 
@@ -161,10 +153,6 @@ sort_order (optional)| string | desc | Order in which records are shown. Default
 ## Get a Specific Decline
 
 ```shell
-curl "https://api.wootric.com/v1/end_users/1/declines/1?access_token=myaccesstoken"
-
-or
-
 curl -H "Authorization: Bearer myaccesstoken" "https://api.wootric.com/v1/end_users/1/declines/1"
 ```
 
@@ -207,10 +195,6 @@ id | integer | The ID of the decline to retrieve
 ## Create Decline
 
 ```shell
-curl -X POST "https://api.wootric.com/v1/end_users/1/declines?access_token=myaccesstoken"
-
-or
-
 curl -X POST -H "Authorization: Bearer myaccesstoken" "https://api.wootric.com/v1/end_users/1/declines"
 ```
 
@@ -232,10 +216,6 @@ end_user.properties (optional) | hash | An object containing the current propert
 ## Update Decline
 
 ```shell
-curl -X PUT "https://api.wootric.com/v1/declines/1?access_token=myaccesstoken" -d "end_user[properties][persona]=Individual"
-
-or
-
 curl -X PUT -H "Authorization: Bearer myaccesstoken" "https://api.wootric.com/v1/declines/1" -d "end_user[properties][persona]=Individual"
 ```
 
@@ -257,10 +237,6 @@ end_user.properties (optional) | hash | An object containing the new set of prop
 ## Delete Decline
 
 ```shell
-curl -X DELETE "https://api.wootric.com/v1/end_users/1/declines/1?access_token=myaccesstoken"
-
-or
-
 curl -X DELETE -H "Authorization: Bearer myaccesstoken" "https://api.wootric.com/v1/end_users/1/declines/1"
 ```
 

--- a/source/includes/_end_user_settings.md
+++ b/source/includes/_end_user_settings.md
@@ -19,10 +19,6 @@ force_mobile_survey | boolean | Flag to override sampling settings. It will make
 ## Get Specific End User Settings
 
 ```shell
-curl "https://api.wootric.com/v1/end_users/1/settings?access_token=myaccesstoken"
-
-or
-
 curl -H "Authorization: Bearer myaccesstoken" "https://api.wootric.com/v1/end_users/1/settings"
 ```
 
@@ -53,10 +49,6 @@ end_user_id | The ID of the end user
 ## Update End User Settings
 
 ```shell
-curl -X PUT "https://api.wootric.com/v1/end_users/1/settings?access_token=myaccesstoken" -d "email_nps=false&force_web_survey=true"
-
-or
-
 curl -X PUT -H "Authorization: Bearer myaccesstoken" "https://api.wootric.com/v1/end_users/1/settings" -d "email_nps=false&force_web_survey=true"
 ```
 

--- a/source/includes/_end_users.md
+++ b/source/includes/_end_users.md
@@ -18,10 +18,6 @@ properties | hash | Properties (i.e. plan, product)
 ## Get All End Users
 
 ```shell
-curl "https://api.wootric.com/v1/end_users?access_token=myaccesstoken"
-
-or
-
 curl -H "Authorization: Bearer myaccesstoken" "https://api.wootric.com/v1/end_users"
 ```
 
@@ -78,10 +74,6 @@ We recommend to iterate using `created` parameter if you need to get more data t
 ## Get a Specific End User by ID
 
 ```shell
-curl "https://api.wootric.com/v1/end_users/2?access_token=myaccesstoken"
-
-or
-
 curl -H "Authorization: Bearer myaccesstoken" "https://api.wootric.com/v1/end_users/2"
 ```
 
@@ -131,10 +123,6 @@ id | The ID of the end user to retrieve
 ## Get a Specific End User by Email
 
 ```shell
-curl "https://api.wootric.com/v1/end_users/nps2@example.com?access_token=myaccesstoken&lookup_by_email=true"
-
-or
-
 curl -H "Authorization: Bearer myaccesstoken" "https://api.wootric.com/v1/end_users/nps2@example.com" -d "lookup_by_email=true"
 ```
 
@@ -185,10 +173,6 @@ lookup_by_email (optional) | Looks the user by email if true. Default value is f
 ## Get a Specific End User by Phone Number
 
 ```shell
-curl "https://api.wootric.com/v1/end_users/phone_number/+14155554131?access_token=myaccesstoken"
-
-or
-
 curl -H "Authorization: Bearer myaccesstoken" "https://api.wootric.com/v1/end_users/phone_number/+14155554131"
 ```
 
@@ -237,10 +221,6 @@ phone_number | The Phone Number of the end user to retrieve. The phone number mu
 ## Create End User
 
 ```shell
-curl -X POST "https://api.wootric.com/v1/end_users?access_token=myaccesstoken" -d "email=enduser@example.com&last_surveyed=1423732280&properties[company]=TestCompany&properties[city]=San Francisco"
-
-or
-
 curl -X POST -H "Authorization: Bearer myaccesstoken" "https://api.wootric.com/v1/end_users" -d "email=enduser@example.com&last_surveyed=1423732280&properties[company]=TestCompany&properties[city]=San Francisco"
 ```
 
@@ -278,10 +258,6 @@ properties (optional) | Hash of additional properties
 ## Update End User
 
 ```shell
-curl -X PUT "https://api.wootric.com/v1/end_users/1?access_token=myaccesstoken" -d "email=enduser_new@example.com&properties[company]=NewCompany&properties[city]=New Reno"
-
-or
-
 curl -X PUT -H "Authorization: Bearer myaccesstoken" "https://api.wootric.com/v1/end_users/1" -d "email=enduser_new@example.com&properties[company]=NewCompany&properties[city]=New Reno"
 ```
 
@@ -322,17 +298,9 @@ properties (optional) | Hash of additional properties
 ```shell
 # Using the end user's ID:
 
-curl -X DELETE "https://api.wootric.com/v1/end_users/1?access_token=myaccesstoken"
-
-or
-
 curl -X DELETE -H "Authorization: Bearer myaccesstoken" "https://api.wootric.com/v1/end_users/1"
 
 # Using the end user's email address:
-
-curl -X DELETE "https://api.wootric.com/v1/end_users/user@domain.com?access_token=myaccesstoken"
-
-or
 
 curl -X DELETE -H "Authorization: Bearer myaccesstoken" "https://api.wootric.com/v1/end_users/user@domain.com"
 ```
@@ -367,10 +335,6 @@ end_user_id_or_email | The ID or the email of the end user to delete
 ## Export specific End User's data
 
 ```shell
-curl "https://api.wootric.com/v1/end_users/2/export?access_token=myaccesstoken"
-
-or
-
 curl -H "Authorization: Bearer myaccesstoken" "https://api.wootric.com/v1/end_users/2/export"
 ```
 

--- a/source/includes/_nps_summary.md
+++ b/source/includes/_nps_summary.md
@@ -17,17 +17,9 @@ email_response_rate | integer | Email response rate percentage for a given date 
 ## Get NPS summary
 
 ```shell
-curl "https://api.wootric.com/v1/nps_summary?access_token=myaccesstoken"
-
-or
-
 curl -H "Authorization: Bearer myaccesstoken" "https://api.wootric.com/v1/nps_summary"
 
 # With params
-
-curl "https://api.wootric.com/v1/nps_summary?access_token=myaccesstoken?date%5Bstart%5D='YYYY-MM-DD'&date%5Bend%5D='YYYY-MM-DD'"
-
-or
 
 curl -H "Authorization: Bearer myaccesstoken" "https://api.wootric.com/v1/nps_summary?date%5Bstart%5D='YYYY-MM-DD'&date%5Bend%5D='YYYY-MM-DD'"
 ```

--- a/source/includes/_responses.md
+++ b/source/includes/_responses.md
@@ -23,10 +23,6 @@ end_user.properties | hash | The end user properties at the moment the survey wa
 ## Get All Responses
 
 ```shell
-curl "https://api.wootric.com/v1/responses?access_token=myaccesstoken"
-
-or
-
 curl -H "Authorization: Bearer myaccesstoken" "https://api.wootric.com/v1/responses"
 ```
 
@@ -109,10 +105,6 @@ We recommend to iterate using `created` parameter if you need to get more data t
 ## Get All End User's Responses
 
 ```shell
-curl "https://api.wootric.com/v1/end_users/1/responses?access_token=myaccesstoken"
-
-or
-
 curl -H "Authorization: Bearer myaccesstoken" "https://api.wootric.com/v1/end_users/1/responses"
 ```
 
@@ -197,10 +189,6 @@ We recommend to iterate using `created` parameter if you need to get more data t
 ## Get All Promoters Responses
 
 ```shell
-curl "https://api.wootric.com/v1/end_users/1/responses/promoters?access_token=myaccesstoken"
-
-or
-
 curl -H "Authorization: Bearer myaccesstoken" "https://api.wootric.com/v1/end_users/1/responses/promoters"
 ```
 
@@ -281,10 +269,6 @@ sort_order (optional)| string | desc | Order in which records are shown. Default
 ## Get All Passives Responses
 
 ```shell
-curl "https://api.wootric.com/v1/end_users/1/responses/passives?access_token=myaccesstoken"
-
-or
-
 curl -H "Authorization: Bearer myaccesstoken" "https://api.wootric.com/v1/end_users/1/responses/passives"
 ```
 
@@ -366,10 +350,6 @@ sort_order (optional)| string | desc | Order in which records are shown. Default
 ## Get All Detractors Responses
 
 ```shell
-curl "https://api.wootric.com/v1/end_users/1/responses/detractors?access_token=myaccesstoken"
-
-or
-
 curl -H "Authorization: Bearer myaccesstoken" "https://api.wootric.com/v1/end_users/1/responses/detractors"
 ```
 
@@ -453,10 +433,6 @@ sort_order (optional)| string | desc | Order in which records are shown. Default
 ## Get a Specific Response
 
 ```shell
-curl "https://api.wootric.com/v1/end_users/2/responses/2?access_token=myaccesstoken"
-
-or
-
 curl -H "Authorization: Bearer myaccesstoken" "https://api.wootric.com/v1/end_users/2/responses/2"
 ```
 
@@ -505,10 +481,6 @@ id | integer | The ID of the decline to retrieve
 ## Create Response
 
 ```shell
-curl -X POST "https://api.wootric.com/v1/end_users/1/responses?access_token=myaccesstoken" -d "score=5&text=test response&ip_address=192.168.0.1&origin_url=http://example.com"
-
-or
-
 curl -X POST -H "Authorization: Bearer myaccesstoken" "https://api.wootric.com/v1/end_users/1/responses" -d "score=5&text=test response&ip_address=192.168.0.1&origin_url=http://example.com"
 ```
 
@@ -533,10 +505,6 @@ end_user.properties (optional) | hash | An object containing the current propert
 ## Update Response
 
 ```shell
-curl -X PUT "https://api.wootric.com/v1/responses/1?access_token=myaccesstoken" -d "completed=true&excluded_from_calculations=false"
-
-or
-
 curl -X PUT -H "Authorization: Bearer myaccesstoken" "https://api.wootric.com/v1/responses/1" -d "completed=true&excluded_from_calculations=false"
 ```
 
@@ -560,10 +528,6 @@ end_user.properties (optional) | hash | An object containing the new set of prop
 ## Delete Response
 
 ```shell
-curl -X DELETE "https://api.wootric.com/v1/end_users/1/responses/1?access_token=myaccesstoken"
-
-or
-
 curl -X DELETE -H "Authorization: Bearer myaccesstoken" "https://api.wootric.com/v1/end_users/1/responses/1"
 ```
 

--- a/source/includes/_segments.md
+++ b/source/includes/_segments.md
@@ -13,10 +13,6 @@ created_at | datetime | Datetime representation of when the segment was created
 ## Get All Segments
 
 ```shell
-curl "https://api.wootric.com/v1/segments?access_token=myaccesstoken"
-
-or
-
 curl -H "Authorization: Bearer myaccesstoken" "https://api.wootric.com/v1/segments"
 ```
 


### PR DESCRIPTION
Changes:
- Update docs to remove all reference to passing access_token as query parameter.
- We should only show passing token as HEADER `Authorization: Bearer`

Test: Checkout branch locally, run app and see if all such reference are removed.

Trello: https://trello.com/c/sLFEyjA4/6380-update-docs-page-to-remove-reference-to-passing-access-token-as-query-paramter