### PR TITLE
Adds CXI API documentation

### DIFF
--- a/source/cxi.html.erb
+++ b/source/cxi.html.erb
@@ -1,0 +1,15 @@
+---
+title: REST API Documentation
+
+toc_footers:
+  - © 2021 Wootric&nbsp; | &nbsp;Docs powered by <a href='http://github.com/tripit/slate'>Slate</a>
+
+includes:
+  - cxi/api_index
+  - cxi/onboarding
+  - cxi/projects
+  - cxi/tags
+  - cxi/imports
+  - cxi/responses
+  - cxi/exports
+---

--- a/source/includes/cxi/_api_index.md
+++ b/source/includes/cxi/_api_index.md
@@ -1,0 +1,80 @@
+---
+title: CXI API Reference
+
+language_tabs:
+  - shell
+
+toc_footers:
+  - © 2021 Wootric&nbsp; | &nbsp;Docs powered by <a href='http://github.com/tripit/slate'>Slate</a>
+
+search: true
+---
+
+# Introduction
+
+Welcome to the CXI API documentation!
+
+You can use our API to access, create and update your imports and responses.
+
+All HTTP responses from the API (including errors) are in JSON. All code examples are in cURL.
+
+# Authentication
+
+In order to use the CXI API you need to get an access token for your CXI account from the main Wootric Application, see [here](api#authentication) for more details
+
+Access tokens can be retrieved using either grant_type of `password` with your account `email` and `password`, or grant_type of `client_credentials` with your application `client_id` and `client_secret`.
+
+> To retrieve an access token using OAuth as following:
+
+```shell
+curl -i https://api.wootric.com/oauth/token?account_token=NPS-XXXX \
+     -F grant_type=password \
+     -F username=<youremailaddress> \
+     -F password=<yourpassword>
+```
+
+> The above command returns the following JSON:
+
+```json
+{
+  "access_token":"<youraccesstoken>",
+  "token_type":"bearer",
+  "expires_in":7200,
+  "refresh_token":"<yourrefreshtoken>",
+  "scope":"public"
+}
+```
+
+> The same but using credentials:
+
+```shell
+curl -X POST https://api.wootric.com/oauth/token \
+     -F grant_type=client_credentials \
+     -F client_id=<yourclientid> \
+     -F client_secret=<yourclientsecret>
+```
+
+> The above command returns the following JSON:
+
+```json
+{
+  "access_token":"<youraccesstoken>",
+  "token_type":"bearer",
+  "expires_in":7200,
+  "scope":"public"
+}
+```
+
+CXI expects the access token to be included in all API requests regardless of grant_type of `password` or `client_credentials`. We recommend to send your token as HTTP `Authorization Header`, for example
+
+`curl -X GET -H "Authorization: Bearer <youraccesstoken>" https://cxi-api.wootric.com/v1/imports`
+
+Access tokens expire 2 hours after creation. New access_token can be obtained using refresh tokens as detailed in the [Wootric Authentication section](api#authentication).
+
+<aside class="notice">
+You must replace `myaccesstoken` with your personal Access Token.
+</aside>
+
+<aside class="notice">
+Never send your credentials (password or client_secret) as query parameter to URL even when using POST request. Query parameters get logged in plain text as your API requests hop through different servers on the way to Wootric servers and hence it can be **exploited**.
+</aside>

--- a/source/includes/cxi/_exports.md
+++ b/source/includes/cxi/_exports.md
@@ -1,0 +1,27 @@
+# Exports
+
+## Create an export
+
+```shell
+curl -i -s -X POST -H "Authorization: Bearer myaccesstoken" "https://cxi-api.wootric.com/v1/exports"
+```
+
+> The above command returns and empty response with status 201 Created.
+
+This endpoint creates an export that will send an email to the user that requested the export once the export is ready.
+
+In the email you'll see a link to download a CSV file containing the data that you requested. If you've chosen `responses` as the `export_type` you'll get a link to a CSV file containing your responses and associated data, if you've chosen `users` as the `export_type` you'll get data associated with your users in the CSV file.
+
+### HTTP Request
+
+`POST https://cxi-api.wootric.com/v1/exports`
+
+### URL Parameters
+
+Parameter | Type | Default | Description
+--------- | ---- | ------- | ----
+export_type | string | responses | The type of export, either `responses` or `users`
+
+### Limits
+
+Your can only have a single export in progress at the same time, so if you requested an export and want another one, you need to wait until you get the first export before requesting the new one.

--- a/source/includes/cxi/_imports.md
+++ b/source/includes/cxi/_imports.md
@@ -1,0 +1,316 @@
+# Imports
+
+## Import Object
+
+An Import object has the following fields:
+
+Attribute | Type | Description
+--------- | ------- | -----------
+id | integer | The ID of the import
+name | string | Import's name
+source | string | Import's source
+metric_type | string | Import's Metric Type, "nps", "ces", "csat" or "other"
+language | string | Import's language
+secondary_product_category_id | integer | Import's optional secondary product category ID
+response_count | integer | The number of responses in this import
+created_at | timestamp | Unix Timestamp of when the import was created
+sample_analyzed | boolean | A boolean indicating whether the import has been analyzed or not
+
+<aside class="notice">
+In the following cURL examples you must replace `myaccesstoken` with a valid [Access Token](api#authentication) obtained from the main application.
+</aside>
+
+## Get imports
+
+This endpoint gets all imports in your account
+
+```shell
+curl -s -H "Authorization: Bearer myaccesstoken" -X GET "https://cxi-api.wootric.com/v1/imports" | jq
+```
+
+> The above command returns a JSON response similar to this:
+
+```json
+[
+  {
+    "id": 6,
+    "name": "ai.csv",
+    "source": "Intercom",
+    "metric_type": "nps",
+    "language": "en",
+    "secondary_product_category_id": null,
+    "response_count": 2,
+    "created_at": 1590090287
+  },
+  {
+    "id": 4,
+    "name": "sample.csv",
+    "source": "Survey Monkey",
+    "metric_type": "nps",
+    "language": "en",
+    "secondary_product_category_id": null,
+    "response_count": 6,
+    "created_at": 1588629685
+  },
+  ...
+]
+```
+
+### HTTP Request
+
+`GET https://cxi-api.wootric.com/v1/imports`
+
+### URL Parameters
+
+Parameter | Type | Default | Description
+--------- | ---- | ------- | -----------
+page (optional)| integer | 1 | Number of returned page, max 30
+per_page (optional) | integer | 25 | Number of records returned on each page, max 50
+
+## Get a specific import
+
+This endpoint gets a specific import by ID and it'd give you more information about an import than the previous endpoint.
+
+```shell
+curl -s -H "Authorization: Bearer myaccesstoken" -X GET "https://cxi-api.wootric.com/v1/imports/6" | jq
+```
+
+> The above command returns a JSON response similar to this:
+
+```json
+{
+  "id": 6,
+  "name": "ai.csv",
+  "source": "Intercom",
+  "metric_type": "nps",
+  "language": "en",
+  "secondary_product_category_id": null,
+  "response_count": 2,
+  "created_at": 1590090287,
+  "sample_analyzed": true,
+  "responses": [
+    ... list of responses in this import
+  ]
+}
+```
+
+### HTTP Request
+
+`GET https://cxi-api.wootric.com/v1/imports/<id>`
+
+### URL Parameters
+
+Parameter | Type | Description
+--------- | ---- | -------
+id | integer | The ID of the import
+
+## Create an import
+
+This endpoint creates an import by uploading a CSV file to /v1/imports, this is a multipart formpost endpoint, so you need to use the proper Content-Type multipart/form-data header.
+
+### CSV file format
+
+For each row in the CSV file we'll create a response in the newly created import, special column names such as `feedback`, `score`, `user_id` and `feedback_date` will be used to create the response and the rest of the columns will be treated as "properties".
+
+The only mandatory column in the CSV file is the `feedback_date` column and it should have a valid value for each row in the file.
+Also if you include a `score` column it should consists of Integer values only (blank values are allowed).
+
+Special columns used as response attributes:
+
+Column | Description | Type | Mandatory
+---- | ---- | ---- | ----
+feedback | the response's feedback | string | false
+feedback_date | the response's feedback date (*)as a Unix Timestamp | String/Integer | **true**
+user_id | the user's unique ID | string | false
+score | the response's NPS, CSAT, CES or other score | Integer | false
+
+Reserved Column Names that cannot be used in the CSV file:
+`tags, wootric_response_id `
+
+(*) feedback_date format: `yyyy-mm-dd hh:mm:ss` (e.g 2020-07-16 15:45:00), we also accept `yyyy-mm-dd hh:mm` and `yyyy-mm-dd`. You can also use a Unix Timestamp.
+
+### Limits
+
+Imports only work for CSVs less than 10MB in size
+
+### HTTP Request
+
+`POST https://cxi-api.wootric.com/v1/imports`
+
+### HTTP Headers
+
+`Content-Type: multipart/form-data`
+
+### HTTP POST Body
+
+Multipart Name | Type | Description
+--------- | ---- | -------
+file | UTF-8 encoded string | The contents of the CSV file (max: 10 MB)
+
+
+```shell
+curl -s -H "Authorization: Bearer myaccesstoken" -XPOST "https://cxi-api.wootric.com/v1/imports" -F "file=@data.csv" | jq
+```
+
+> The above command returns a JSON response similar to this:
+
+```json
+{
+  "id": 11,
+  "name": "data.csv",
+  "source": null,
+  "metric_type": null,
+  "language": "en",
+  "secondary_product_category_id": null,
+  "response_count": 0,
+  "created_at": 1611093660,
+  "sample_analyzed": false,
+  "responses": [
+    {
+      "id": 403,
+      "project_ids": [],
+      "feedback": "I wish your pricing model worked better for me. I need a custom plan.",
+      "translated_feedback": null,
+      "user_id": "mitsu.takasu@example1434.mx",
+      "feedback_date": 1504948149,
+      "score": 7,
+      "metric_type": null,
+      "custom_properties": [
+        {
+          "key": "platform",
+          "data_type": "string",
+          "value": "Solaris"
+        },
+        {
+          "key": "country",
+          "data_type": "string",
+          "value": "Ecuador"
+        },
+        {
+          "key": "pricing_plan",
+          "data_type": "string",
+          "value": "Lite"
+        },
+        {
+          "key": "persona",
+          "data_type": "string",
+          "value": "Business User"
+        }
+      ],
+      "tags": [],
+      "sentiment": null,
+      "wootric_response_id": null,
+      "wootric_account_id": 38
+    },
+    ... list of responses in your import
+  ]
+}
+```
+
+## Update an import
+
+This endpoint updates an import's metadata. The name, metric_type and source fields can be set with `PUT /v1/imports/:id`.
+Also, this endpoint accepts an optional list of tag_names and project_ids.
+
+### HTTP Request
+
+`PUT https://cxi-api.wootric.com/v1/imports/<id>`
+
+### URL Parameters
+
+Parameter | Type | Description
+--------- | ---- | -------
+id | integer | The ID of the import
+import[name] | string | Import's name
+import[source] | string | Import's source
+import[metric_type] | string | Import's Metric Type, "nps", "ces", "csat" or "other"
+import[language] | string | Import's language
+import[secondary_product_category_id] | integer | Import's optional secondary product category ID
+import[tag_names] | string[] | List of **existing** `Tag` names in the account that will be applied to each response in the import.
+import[project_ids] | integer[] | List of **existing** `project IDs that will be applied to each response in the import.
+
+```shell
+curl -s -H "Authorization: Bearer myaccesstoken" -X PUT "https://cxi-api.wootric.com/v1/imports/11" \
+  -F import[name]="My second import" \
+  -F import[metric_type]=CES \
+  -F import[source]=Intercom \
+  -F import[tag_names][0]=TEST \
+  -F import[project_ids][0]=5 | jq
+```
+
+> The above command returns a JSON response similar to this:
+
+```json
+{
+  "id": 11,
+  "name": "My second import",
+  "source": "Intercom",
+  "metric_type": "ces",
+  "language": "en",
+  "secondary_product_category_id": null,
+  "response_count": 0,
+  "created_at": 1611093660,
+  "sample_analyzed": false,
+  "responses": [
+    {
+      "id": 413,
+      "project_ids": [
+        5
+      ],
+      "feedback": "I wish your pricing model worked better for me. I need a custom plan.",
+      "translated_feedback": null,
+      "user_id": "mitsu.takasu@example1434.mx",
+      "feedback_date": 1504948149,
+      "score": 7,
+      "metric_type": "ces",
+      "custom_properties": [
+        {
+          "key": "pricing_plan",
+          "data_type": "string",
+          "value": "Lite"
+        },
+        {
+          "key": "platform",
+          "data_type": "string",
+          "value": "Solaris"
+        },
+        {
+          "key": "persona",
+          "data_type": "string",
+          "value": "Business User"
+        },
+        {
+          "key": "country",
+          "data_type": "string",
+          "value": "Ecuador"
+        }
+      ],
+      "tags": [],
+      "sentiment": null,
+      "wootric_response_id": null,
+      "wootric_account_id": 38
+    },
+    ... list of responses in your import
+  ]
+}
+```
+
+## Delete an import
+
+```shell
+curl -i -s -X DELETE -H "Authorization: Bearer myaccesstoken" "https://cxi-api.wootric.com/v1/imports/10"
+```
+
+> The above command returns and empty response with status 202 Accepted.
+
+This endpoint deletes an import in your account along with all associated responses.
+
+### HTTP Request
+
+`DELETE https://cxi-api.wootric.com/v1/imports/<id>`
+
+### URL Parameters
+
+Parameter | Type | Description
+--------- | ---- | -------
+id | integer | The ID of the import

--- a/source/includes/cxi/_onboarding.md
+++ b/source/includes/cxi/_onboarding.md
@@ -1,0 +1,306 @@
+# Onboarding
+
+In order to use the CXI API you first need an "onboarded" account, that is, you should have completed the onboarding flow, which is required to access the rest of the API.
+
+In the onboarding flow you are asked to choose a Product Category for you account and other details.
+
+The API will return a `424 Failed Dependency` error when trying to perform an action (like fetching imports, tags or responses) using an account that has not completed the onboarding flow.
+
+> Trying to use the API without completing the onboarding flow will give you an error:
+
+```shell
+curl -i -H "Authorization: Bearer myaccesstoken" -X GET "$AI_SERVER/v1/imports"
+HTTP/1.1 424 Failed Dependency
+...
+{"message":"Please complete the onboarding flow first."}
+```
+
+
+## Get Onboarding status
+
+This endpoint will give you the onboarding status of your account
+
+```shell
+curl -s -H "Authorization: Bearer myaccesstoken" -X GET "https://cxi-api.wootric.com/v1/onboarding" | jq
+```
+
+> The above command returns a JSON response similar to this for onboarded accounts
+
+```json
+{
+  "onboarded": true,
+  "mode": "full"
+}
+```
+
+> The above command returns a JSON response similar to this for NOT onboarded accounts
+
+```json
+{
+  "onboarded": false,
+  "mode": "full",
+  "product_category_id": null,
+  "product_categories": [
+    {
+      "id": 1,
+      "name": "General"
+    },
+    {
+      "id": 2,
+      "name": "SaaS DevOps"
+    },
+    {
+      "id": 3,
+      "name": "SaaS Anc"
+    },
+    {
+      "id": 4,
+      "name": "SaaS IDC"
+    },
+    {
+      "id": 5,
+      "name": "SaaS Education CL"
+    },
+    {
+      "id": 6,
+      "name": "SaaS GD"
+    },
+    {
+      "id": 7,
+      "name": "SaaS Social Media"
+    },
+    {
+      "id": 15,
+      "name": "Politicians Review"
+    },
+    {
+      "id": 8,
+      "name": "SaaS Social Media HS"
+    },
+    {
+      "id": 9,
+      "name": "E-Commerce"
+    },
+    {
+      "id": 10,
+      "name": "E-Commerce-WGAC"
+    },
+    {
+      "id": 11,
+      "name": "Employee Reviews"
+    },
+    {
+      "id": 12,
+      "name": "Online Food Delivery"
+    },
+    {
+      "id": 13,
+      "name": "Support Case Feedback"
+    },
+    {
+      "id": 14,
+      "name": "SaaS RC"
+    }
+  ],
+  "tags": []
+}
+```
+
+### HTTP Request
+
+`GET https://cxi-api.wootric.com/v1/onboarding`
+
+
+## Update Onboarding status
+
+This endpoint updates the onboarding status of an account that has not been onboarded yet. Your account will not be onboarded until you update the `onboarded` attribute using this endpoint.
+
+
+```shell
+curl -s -H "Authorization: Bearer myaccesstoken" -X PUT "https://cxi-api.wootric.com/v1/onboarding" \
+  -F product_category_id=9
+  | jq
+```
+
+> The above command returns a JSON response similar to this for onboarded accounts
+
+```json
+{
+  "onboarded": false,
+  "mode": "full",
+  "product_category_id": 9,
+  "product_categories": [
+    {
+      "id": 1,
+      "name": "General"
+    },
+    {
+      "id": 2,
+      "name": "SaaS DevOps"
+    },
+    {
+      "id": 3,
+      "name": "SaaS Anc"
+    },
+    {
+      "id": 4,
+      "name": "SaaS IDC"
+    },
+    {
+      "id": 5,
+      "name": "SaaS Education CL"
+    },
+    {
+      "id": 6,
+      "name": "SaaS GD"
+    },
+    {
+      "id": 7,
+      "name": "SaaS Social Media"
+    },
+    {
+      "id": 15,
+      "name": "Politicians Review"
+    },
+    {
+      "id": 8,
+      "name": "SaaS Social Media HS"
+    },
+    {
+      "id": 9,
+      "name": "E-Commerce"
+    },
+    {
+      "id": 10,
+      "name": "E-Commerce-WGAC"
+    },
+    {
+      "id": 11,
+      "name": "Employee Reviews"
+    },
+    {
+      "id": 12,
+      "name": "Online Food Delivery"
+    },
+    {
+      "id": 13,
+      "name": "Support Case Feedback"
+    },
+    {
+      "id": 14,
+      "name": "SaaS RC"
+    }
+  ],
+  "tags": [
+    {
+      "id": 90,
+      "mode": "smart",
+      "name": "RETURNS",
+      "response_ids": []
+    },
+    {
+      "id": 91,
+      "mode": "smart",
+      "name": "SHIPPING_PACKAGING",
+      "response_ids": []
+    },
+    ...
+    {
+      "id": 89,
+      "mode": "smart",
+      "name": "PRODUCT_QUALITY",
+      "response_ids": []
+    }
+  ],
+  "project": {
+    "name": null,
+    "responses": []
+  }
+}
+```
+
+<aside class="warning">
+Note that your can use this endpoint as long as the `onboarded` attribute is `false`, once you update it to `true` you can no longer use this endpoint but you'll be able to access the rest of the API.
+</aside>
+
+### HTTP Request
+
+`PUT https://cxi-api.wootric.com/v1/onboarding`
+
+### URL Parameters
+
+Parameter | Type | Description
+--------- | ---- | -------
+product_category_id | integer | The ID of the chosen Product Category
+onboarded | boolean | Onboarding status flag
+project | Hash | (optional) Details about an optional associated Project
+import | Hash | (optional) Details about an optional associated Import (see [Imports API](cxi#imports))
+project[name] | string | Name of an associated Project (see [Projects API](cxi#projects))
+import[name] | string | Name of an associated Import (see [Imports API](cxi#imports))
+import[source] | string | Import's source (see [Imports API](cxi#imports))
+import[metric_type] | string | Import's Metric Type (see [Imports API](cxi#imports))
+import[language] | string | Import's language (see [Imports API](cxi#imports))
+
+
+```shell
+curl -s -H "Authorization: Bearer myaccesstoken" -X PUT "https://cxi-api.wootric.com/v1/onboarding" \
+  -F project[name]=Enterprise \
+  -F import[name]=important.csv \
+  -F import[source]="Survey Monkey" \
+  -F import[metric_type]=NPS \
+  | jq
+```
+
+> The above command returns a JSON response similar to this for onboarded accounts
+
+```json
+{
+  "onboarded": false,
+  "mode": "full",
+  "product_category_id": 9,
+  "product_categories": [
+    {
+      "id": 1,
+      "name": "General"
+    },
+    {
+      "id": 9,
+      "name": "E-Commerce"
+    },
+    ...
+  ],
+  "tags": [
+    {
+      "id": 90,
+      "mode": "smart",
+      "name": "RETURNS",
+      "response_ids": []
+    },
+    ...
+  ],
+  "project": {
+    "name": "Enterprise",
+    "responses": []
+  },
+  "import": {
+    "name": "important.csv",
+    "source": "Survey Monkey",
+    "metric_type": "nps",
+    "sample_analyzed": true
+  }
+}
+```
+
+> Finally, the onboarded state is also set through the same PUT /v1/onboarding endpoint:
+
+```shell
+$ curl -s -H "Authorization: Bearer myaccesstoken" -X PUT "https://cxi-api.wootric.com/v1/onboarding" -F onboarded=true | jq
+{
+  "onboarded": true,
+  "mode": "full"
+}
+```
+
+<aside class="warning">
+From now on all examples assume that your account has been onboarded and you have successfully selected a Product Category for your account and have also created your first import.
+</aside>

--- a/source/includes/cxi/_projects.md
+++ b/source/includes/cxi/_projects.md
@@ -1,0 +1,102 @@
+# Projects
+
+## Project Object
+
+A Project object has the following fields:
+
+Attribute | Type | Description
+--------- | ------- | -----------
+id | integer | The ID of project
+name | string | Project's name
+response_count | integer | Number of Responses in this Project
+created_at | integer | Project's creation date as a Unix Timestamp
+
+<aside class="notice">
+In the following cURL examples you must replace `myaccesstoken` with a valid [Access Token](api#authentication) obtained from the main application.
+</aside>
+
+## Get projects
+
+This endpoint gets all projects in your account
+
+```shell
+curl -s -H "Authorization: Bearer myaccesstoken" -X GET "https://cxi-api.wootric.com/v1/projects" | jq
+```
+
+> The above command returns a JSON response similar to this:
+
+```json
+[
+  {
+    "id": 7,
+    "name": "Enterprise",
+    "response_count": 0,
+    "created_at": 1610774054
+  }
+]
+```
+
+### HTTP Request
+
+`GET https://cxi-api.wootric.com/v1/projects`
+
+## Create a Project
+
+```shell
+curl -X POST -H "Authorization: Bearer myaccesstoken" "https://cxi-api.wootric.com/v1/projects" \
+  -F project[name]="My new Project"
+```
+
+> The above command returns a JSON response similar to this:
+
+```json
+{
+  "id": 8,
+  "name": "My new Project",
+  "response_count": 0,
+  "created_at": 1611092961
+}
+```
+
+This endpoint creates a project in your account.
+
+### HTTP Request
+
+`POST https://cxi-api.wootric.com/v1/projects`
+
+### URL Parameters
+
+Parameter | Type | Description
+--------- | ---- | -----------
+project[name] | string | Project's name
+
+## Update a Project
+
+```shell
+curl -X PUT -H "Authorization: Bearer myaccesstoken" "https://cxi-api.wootric.com/v1/projects/8" \
+  -F project[name]="Updated name for the Project"
+```
+
+> The above command returns a JSON response similar to this:
+
+```json
+{
+  "id": 8,
+  "name": "Updated name for the Project",
+  "response_count": 0,
+  "created_at": 1611092961
+}
+```
+
+This endpoint updates a project in your account.
+
+### HTTP Request
+
+`PUT https://cxi-api.wootric.com/v1/projects/<ID>`
+
+### URL Parameters
+
+Parameter | Type | Description
+--------- | ---- | -----------
+id  | integer | The ID of the Project being updated
+project[name] | string | Project's name

--- a/source/includes/cxi/_responses.md
+++ b/source/includes/cxi/_responses.md
@@ -1,0 +1,126 @@
+# Reponses
+
+## Response Object
+
+A Response object has the following fields:
+
+Attribute | Type | Description
+--------- | ------- | -----------
+id | integer | The ID of the response
+feedback | string | the response's feedback
+feedback_date | string/integer | the response's feedback date (*) 
+user_id | string | the user's unique ID
+metric_type | string | response's metric type, one of `nps`, `csat`, `ces` or `other`
+score | integer | the response's NPS, CSAT, CES or other score
+sentiment | string | response's sentiment, `positive`, `negative`, `neutral` or `null`
+project_ids | integer[] | Array of all associated [Projects](cxi#projects)
+tags | Hash[] | a list of [Tags](cxi#tags) associated with this response
+custom_properties | Hash[] | a list of associated custom properties for this response (**)
+
+(*) feedback_date format: `yyyy-mm-dd hh:mm:ss` (e.g 2020-07-16 15:45:00), we also accept `yyyy-mm-dd hh:mm` and `yyyy-mm-dd`. You can also use a Unix Timestamp.
+
+(**) custom_properties are associated to responses when you create an [Import](cxi#create-an-import). The properties and their values are the columns and cells that you use in the uploaded CSV file.
+
+<aside class="notice">
+In the following cURL examples you must replace `myaccesstoken` with a valid [Access Token](api#authentication) obtained from the main application.
+</aside>
+
+## Get responses
+
+This endpoint gets all responses in your account
+
+```shell
+curl -s -H "Authorization: Bearer myaccesstoken" -X GET "https://cxi-api.wootric.com/v1/responses" | jq
+```
+
+> The above command returns a JSON response similar to this:
+
+```json
+{
+  "total_count": 10,
+  "items": [
+    {
+      "id": 413,
+      "project_ids": [
+        5
+      ],
+      "feedback": "I wish your pricing model worked better for me. I need a custom plan.",
+      "translated_feedback": null,
+      "user_id": "mitsu.takasu@example1434.mx",
+      "feedback_date": 1504948149,
+      "score": 7,
+      "metric_type": "ces",
+      "custom_properties": [
+        {
+          "key": "pricing_plan",
+          "data_type": "string",
+          "value": "Lite"
+        },
+        {
+          "key": "platform",
+          "data_type": "string",
+          "value": "Solaris"
+        },
+        {
+          "key": "persona",
+          "data_type": "string",
+          "value": "Business User"
+        },
+        {
+          "key": "country",
+          "data_type": "string",
+          "value": "Ecuador"
+        }
+      ],
+      "tags": [
+        {
+          "id": 93,
+          "name": "TECHNICAL",
+          "display_name": "TECHNICAL",
+          "description": null,
+          "mode": "smart",
+          "sentiment": "negative",
+          "text_match_terms": [],
+          "filter_rules": {}
+        },
+        {
+          "id": 87,
+          "name": "PEOPLE",
+          "display_name": "PEOPLE",
+          "description": null,
+          "mode": "smart",
+          "sentiment": "positive",
+          "text_match_terms": [],
+          "filter_rules": {}
+        },
+        {
+          "id": 89,
+          "name": "PRODUCT_QUALITY",
+          "display_name": "PRODUCT_QUALITY",
+          "description": null,
+          "mode": "smart",
+          "sentiment": "negative",
+          "text_match_terms": [],
+          "filter_rules": {}
+        }
+      ],
+      "sentiment": "positive",
+      "wootric_response_id": null,
+      "wootric_account_id": 38
+    },
+    ...
+  ]
+}
+```
+
+### HTTP Request
+
+`GET https://cxi-api.wootric.com/v1/responses`
+
+### URL Parameters
+
+Parameter | Type | Default | Description
+--------- | ---- | ------- | -----------
+page (optional)| integer | 1 | Number of returned page, max 30
+per_page (optional) | integer | 25 | Number of records returned on each page, max 50
+sort_order (optional) | string | desc | Sort responses by `feedback_date` in ascending or descending order

--- a/source/includes/cxi/_tags.md
+++ b/source/includes/cxi/_tags.md
@@ -1,0 +1,201 @@
+# Tags
+
+## Tag Object
+
+A Tag object has the following fields:
+
+Attribute | Type | Description
+--------- | ------- | -----------
+id | integer | The ID of tag
+name | string | Tag's name
+display_name | string | Tag's display name
+description | string | Tag's description
+mode | string | Tag's mode, one of `manual`, `smart` or `text_match`
+enabled | boolean | A boolean indicating whether the tag is enabled or not
+text_match_terms | string[] | An Array of strings indicating the terms that'd be used to match this tag. Only applies to text-match tags.
+filter_rules | Hash | a Hash of conditions (or filters) that should be satisfied before applying this tag to a response. Only applies to text-match tags.
+sentiment_breakdown | Hash | Sentiment percentage breakdown for this tag, `positive`, `negative`, `neutral` and `null` are the possible keys.
+children | Tag[] | Array of Tags that are children of this parent tag
+
+## Get tags
+
+This endpoint gets all tags in your account
+
+```shell
+curl -s -H "Authorization: Bearer myaccesstoken" -X GET "https://cxi-api.wootric.com/v1/tags" | jq
+```
+
+> The above command returns a JSON response similar to this:
+
+```json
+[
+  {
+    "id": 46,
+    "name": "PERFORMANCE",
+    "display_name": "PERFORMANCE",
+    "description": null,
+    "mode": "smart",
+    "enabled": true,
+    "scope_by_parent": null,
+    "text_match_terms": [],
+    "filter_rules": {},
+    "response_count": 39,
+    "usage": 48.148148148148145,
+    "sentiment_breakdown": {
+      "positive": 46.15,
+      "neutral": 17.95,
+      "negative": 35.9,
+      "null": 0
+    },
+    "children": []
+  },
+  {
+    "id": 49,
+    "name": "UX_UI",
+    "display_name": "UX_UI",
+    "description": null,
+    "mode": "smart",
+    "enabled": true,
+    "scope_by_parent": null,
+    "text_match_terms": [],
+    "filter_rules": {},
+    "response_count": 38,
+    "usage": 46.913580246913575,
+    "sentiment_breakdown": {
+      "positive": 36.84,
+      "neutral": 18.42,
+      "negative": 44.74,
+      "null": 0
+    },
+    "children": []
+  },
+  ...
+]
+```
+
+### HTTP Request
+
+`GET https://cxi-api.wootric.com/v1/tags`
+
+### URL Parameters
+
+Parameter | Type | Default | Description
+--------- | ---- | ------- | -----------
+page (optional)| integer | 1 | Number of returned page, max 30
+per_page (optional) | integer | 25 | Number of records returned on each page, max 50
+flat | boolean | false | Return children tags inside a `children` array in the parent tag object (hierarchy), or return children tags on their own (flat)
+sort | string | response_count descending | How to sort results, possible values: `name_asc`, `name_desc` and `responses_asc`. The default is to sort results by response count in descending mode.
+search | string | nil | Used to search (full text search) for matching tag names
+no_stats | boolean | false | Whether to include usage data statistics or not
+exclude_disabled | boolean | false | If true then only enabled tags will be returned
+
+## Create a Tag
+
+This endpoint creates a tag in your account, only manual and text-match tags can be created.
+
+```shell
+curl -s -H "Authorization: Bearer myaccesstoken" -X POST "https://cxi-api.wootric.com/v1/tags" \
+  -F tag[name]=my-tag \
+  -F tag[description]="the descrition" \
+  -F tag[mode]=text_match \
+  -F tag[text_match_terms][]="term1" \
+  -F tag[text_match_terms][]="term2" \
+  -F tag[text_match_terms][]="term3" \
+  | jq
+```
+
+> The above command returns a JSON response similar to this:
+
+```json
+{
+  "id": 78,
+  "name": "MY-TAG",
+  "display_name": "MY-TAG",
+  "description": "the descrition",
+  "mode": "text_match",
+  "enabled": true,
+  "scope_by_parent": false,
+  "text_match_terms": [
+    "term1",
+    "term2",
+    "term3"
+  ],
+  "filter_rules": {}
+}
+```
+
+### HTTP Request
+
+`POST https://cxi-api.wootric.com/v1/tags`
+
+### URL Parameters
+
+Parameter | Type | Description
+--------- | ---- | -------
+tag[name] | string | The tag's name
+tag[description] | string | Tag's description
+tag[mode] | string | Tag's mode, one of `manual` or `text_match`
+tag[parent_id] | integer | The ID of a Tag that will be used as parent for this tag
+tag[text_match_terms] | string[] | An Array of strings indicating the terms that'd be used to match this tag. Only applies to text-match tags. Max: 100
+tag[filter_rules] | Hash | a Hash of conditions (or filters) that should be satisfied before applying this tag to a response. Only applies to text-match tags.
+
+## Update a Tag
+
+This endpoint updates a tag in your account
+
+```shell
+curl -s -H "Authorization: Bearer myaccesstoken" -X PUT "https://cxi-api.wootric.com/v1/tags/78" \
+  -F tag[name]=my-updated-tag \
+  -F tag[description]="the updated descrition" \
+  -F tag[text_match_terms][]="term3" \
+  -F tag[text_match_terms][]="term4" \
+  | jq
+```
+
+> The above command returns a JSON response similar to this:
+
+```json
+{
+  "id": 78,
+  "name": "MY-UPDATED-TAG",
+  "display_name": "MY-UPDATED-TAG",
+  "description": "the updated descrition",
+  "mode": "text_match",
+  "enabled": true,
+  "scope_by_parent": false,
+  "text_match_terms": [
+    "term3",
+    "term4"
+  ],
+  "filter_rules": {}
+}
+```
+
+### HTTP Request
+
+`PUT https://cxi-api.wootric.com/v1/tags/<ID>`
+
+### URL Parameters
+
+Parameter | Type | Description
+--------- | ---- | -------
+tag[name] | string | The tag's name
+tag[description] | string | Tag's description
+tag[mode] | string | Tag's mode, one of `manual` or `text_match`
+tag[parent_id] | integer | The ID of a Tag that will be used as parent for this tag
+tag[text_match_terms] | string[] | An Array of strings indicating the terms that'd be used to match this tag. Only applies to text-match tags. Max: 100
+tag[filter_rules] | Hash | a Hash of conditions (or filters) that should be satisfied before applying this tag to a response. Only applies to text-match tags.
+
+## Delete a Tag
+
+This endpoint deletes a tag in your account
+
+```shell
+curl -s -H "Authorization: Bearer myaccesstoken" -X DELETE "https://cxi-api.wootric.com/v1/tags/78" | jq
+```
+
+> The above command returns an empty response with status 200.
+
+### HTTP Request
+
+`DELETE https://cxi-api.wootric.com/v1/tags/<ID>`

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -1,6 +1,11 @@
 <%
   sdks = [
     {
+      icon: 'api',
+      href: '/cxi',
+      name: 'CXI API',
+    },
+    {
       icon: 'javascript',
       href: '/javascript',
       name: 'Install Wootric using JavaScript',


### PR DESCRIPTION
## Changes
- Adds a new CXI section to the documentation which includes information
about how to use part of the CXI API:
  - Authentication
  - Onboarding
  - Projects
  - Tags
  - Imports
  - Responses
  - Exports

## Trello Card
https://trello.com/c/KToWRybZ/7114-cxi-api-docs

## How to test
- move to this branch
- `cd build`
- `bundle exec middleman server`
- go to `http://192.168.1.36:4567` and look for the CXI API docs

![image](https://user-images.githubusercontent.com/120909/105103947-26f03900-5a90-11eb-9dc8-fedd2b779a69.png)
