### PR TITLE
Move CXI docs icon

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -1,11 +1,6 @@
 <%
   sdks = [
     {
-      icon: 'api',
-      href: '/cxi',
-      name: 'CXI API',
-    },
-    {
       icon: 'javascript',
       href: '/javascript',
       name: 'Install Wootric using JavaScript',
@@ -44,6 +39,11 @@
       icon: 'api',
       href: '/api',
       name: 'REST API'
+    },
+    {
+      icon: 'api',
+      href: '/cxi',
+      name: 'CXI API',
     },
     {
       icon: 'webhooks',


### PR DESCRIPTION
Move the CXI API docs icon to the bottom of the index page:

![image](https://user-images.githubusercontent.com/120909/105534391-31971200-5ccc-11eb-910a-6443af4684e3.png)
