### PR TITLE
Update delete end_user documentation

### DIFF
--- a/source/includes/_end_users.md
+++ b/source/includes/_end_users.md
@@ -474,7 +474,8 @@ curl -X DELETE -H "Authorization: Bearer myaccesstoken" "https://api.wootric.com
   }
 ```
 
-This endpoint marks the end user for deletion. Deletion would be performed the following day at 7 AM UTC.
+This endpoint marks the end user for deletion. Deletion would be scheduled the following day at 7 AM UTC.
+Depending on the size of our queues at the time it could take several hours to finish processing.
 
 ### HTTP Request
 


### PR DESCRIPTION
Update delete end_user documentation

## Changes
- Clearly state that when deleting end_users using the API, the deletion
  process will be *scheduled* the next day (instead of performed)

## JIRA story
https://jira.inmoment.com/browse/DEV-20985

## JIRA Code Review / QA subtask
https://jira.inmoment.com/browse/DEV-21022