### PR TITLE
Update Android version

### DIFF
--- a/source/includes/_install_android.md
+++ b/source/includes/_install_android.md
@@ -5,7 +5,7 @@
 <dependency>
     <groupId>com.wootric</groupId>
     <artifactId>wootric-sdk-android</artifactId>
-    <version>2.15.0</version>
+    <version>2.21.1</version>
 </dependency>
 ```
 


### PR DESCRIPTION
Android version is outdated. Fixing to latest version `2.21.1`: https://github.com/Wootric/WootricSDK-Android/releases/tag/2.21.1

## Test

1. Checkout this branch
2. Run `bundle exec middleman server`
3. Go to http://localhost:4567/android and check that the new version is showing up correctly

## Jira

No jira ticket, I realized this by looking into a customer support issue: https://inmoment.slack.com/archives/C024MR3B67J/p1651779803723749